### PR TITLE
Generate a demo world

### DIFF
--- a/GameRealisticMap.Arma3.CommandLine/Program.cs
+++ b/GameRealisticMap.Arma3.CommandLine/Program.cs
@@ -1,8 +1,11 @@
 ﻿using System.Diagnostics;
 using System.Text.Json;
+using System.Threading.Tasks;
 using GameRealisticMap.Arma3.Assets;
+using GameRealisticMap.Arma3.GameEngine;
 using GameRealisticMap.Arma3.IO;
 using GameRealisticMap.Arma3.TerrainBuilder;
+using GameRealisticMap.ElevationModel;
 using GameRealisticMap.Osm;
 using GameRealisticMap.Preview;
 using GameRealisticMap.Reporting;
@@ -14,45 +17,18 @@ namespace GameRealisticMap.Arma3.CommandLine
     {
         static async Task Main(string[] args)
         {
+
+
+
             var projectDrive = new ProjectDrive(Arma3ToolsHelper.GetProjectDrivePath(), new PboFileSystem());
 
             projectDrive.AddMountPoint(@"z\arm\addons", @"C:\Users\Julien\source\repos\ArmaRealMap\PDrive\z\arm\addons");
 
-            var a3config = new Arma3MapConfigJson()
-            {
-                SouthWest = "47.6856, 6.8270",
-                GridSize = 1024,
-                GridCellSize = 2.5f,
-                AssetConfigFile = @"C:\Users\Julien\source\repos\ArmaRealMap\ArmToGrmA3\bin\Debug\net6.0\CentralEurope.json",
-                TileSize = 512
-            }.ToArma3MapConfig();
+            var models = new ModelInfoLibrary(projectDrive);
 
+            var generator = new Arma3DemoMapGenerator(await Arma3Assets.LoadFromFile(models,"builtin:CentralEurope.grma3a"), projectDrive, "CentralEurope");
 
-            var progress = new ConsoleProgressSystem();
-
-            var library = new ModelInfoLibrary(projectDrive);
-
-            var assets = await Arma3Assets.LoadFromFile(library, a3config.AssetConfigFile);
-
-            var sw = Stopwatch.StartNew();
-
-            var generator = new Arma3MapGenerator(assets, projectDrive);
-
-            var context = await generator.GenerateWrp(progress, a3config);
-
-            sw.Stop();
-
-            context?.DisposeHugeImages();
-
-            var surface = a3config.SizeInMeters * a3config.SizeInMeters / 1000000d;
-
-            Console.WriteLine($"It took {sw.ElapsedMilliseconds} msec for {surface:0.0} Km², {sw.ElapsedMilliseconds / surface:0} msec/Km²");
-
-            var all = context.Catalog.GetOfType<IGeoJsonData>(context).SelectMany(d => d.ToGeoJson(p => p)).ToList();
-
-            await PreviewRender.RenderHtml(new FeatureCollection(all), Path.GetFullPath("preview.html"));
-
-            await Arma3ToolsHelper.BuildWithMikeroPboProject(a3config.PboPrefix, @"C:\temp\@ArmTest", progress);
+            var config = await generator.GenerateMod(new ConsoleProgressSystem());
         }
     }
 }

--- a/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
+++ b/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
@@ -1,38 +1,25 @@
-﻿using System.Numerics;
-using System.Runtime.Versioning;
+﻿using System.Runtime.Versioning;
 using BIS.WRP;
 using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.IO;
+using GameRealisticMap.Demo;
 using GameRealisticMap.ElevationModel;
-using GameRealisticMap.Geometries;
-using GameRealisticMap.ManMade;
-using GameRealisticMap.ManMade.Farmlands;
-using GameRealisticMap.ManMade.Places;
-using GameRealisticMap.ManMade.Roads;
-using GameRealisticMap.ManMade.Roads.Libraries;
-using GameRealisticMap.Nature.Forests;
-using GameRealisticMap.Nature.Lakes;
-using GameRealisticMap.Nature.RockAreas;
-using GameRealisticMap.Nature.Scrubs;
-using GameRealisticMap.Nature.Surfaces;
-using GameRealisticMap.Nature.Watercourses;
 using GameRealisticMap.Osm;
 using GameRealisticMap.Reporting;
 using HugeImages.Storage;
-using SixLabors.ImageSharp.Drawing;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.Processing;
 
 namespace GameRealisticMap.Arma3
 {
     public class Arma3DemoMapGenerator : Arma3MapGenerator
     {
         private readonly string name;
+        private readonly IDemoNaming demoNaming;
 
-        public Arma3DemoMapGenerator(IArma3RegionAssets assets, ProjectDrive projectDrive, string name)
+        public Arma3DemoMapGenerator(IArma3RegionAssets assets, ProjectDrive projectDrive, string name, IDemoNaming? demoNaming = null)
             : base(assets, projectDrive)
         {
             this.name = name;
+            this.demoNaming = demoNaming ?? new DefaultDemoNaming();
         }
 
         protected override Task<IOsmDataSource> LoadOsmData(IProgressTask progress, Arma3MapConfig a3config)
@@ -44,26 +31,7 @@ namespace GameRealisticMap.Arma3
         {
             var context = base.CreateBuildContext(progress, a3config, osmSource, hugeImageStorage);
 
-            var grid = new ElevationGrid(a3config.TerrainArea.GridSize, a3config.TerrainArea.GridCellSize);
-            grid.Fill(15f);
-            context.SetData(new RawElevationData(grid));
-
-            var places = new List<City>();
-
-            CreateSampleSingle(context, places, polygon => new ForestData(polygon), new Vector2(0 * 512, 0));
-            CreateSampleSingle(context, places, polygon => new ScrubData(polygon), new Vector2(1 * 512, 0));
-            CreateSampleSingle(context, places, polygon => new RocksData(polygon), new Vector2(2 * 512, 0));
-            CreateSampleSingle(context, places, polygon => new GrassData(polygon), new Vector2(3 * 512, 0));
-            CreateSampleSingle(context, places, polygon => new MeadowsData(polygon), new Vector2(4 * 512, 0));
-            CreateSampleSingle(context, places, polygon => new SandSurfacesData(polygon), new Vector2(5 * 512, 0));
-            CreateSampleQuad(context, places, polygon => new FarmlandsData(polygon), new Vector2(0 * 512, 512));
-            CreateSampleLakes(context, places, new Vector2(6 * 512, 0));
-            CreateSampleWatercourses(context, places, new Vector2(7 * 512, 0));
-            CreateRoads(context, grid, places);
-
-            places.Add(new City(new TerrainPoint(a3config.TerrainArea.SizeInMeters / 2, a3config.TerrainArea.SizeInMeters / 2), new List<TerrainPolygon>() { a3config.TerrainArea.TerrainBounds }, name + " DEMO", CityTypeId.City, 1024, 10000));
-            context.SetData(new CitiesData(places));
-
+            new DemoMapGenerator(assets.RoadTypeLibrary, demoNaming).CreateInto(context, name);
 
             return context;
         }
@@ -81,115 +49,6 @@ namespace GameRealisticMap.Arma3
             return objects;
         }
 
-        private void CreateRoads(BuildContext context, ElevationGrid grid, List<City> places)
-        {
-            var roads = new List<Road>();
-            int index = 0;
-            foreach(var typeid in Enum.GetValues<RoadTypeId>())
-            {
-                CreateRoad(assets.RoadTypeLibrary.GetInfo(typeid), roads, grid, new Vector2(index * 512, 1024), places);
-                index++;
-            }
-
-            var y = 1024f + 518f;
-
-            foreach (var typeid in Enum.GetValues<RoadTypeId>())
-            {
-                var type = assets.RoadTypeLibrary.GetInfo(typeid);
-
-                roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(new(0, y), new(5120, y)), type));
-
-                y += type.ClearWidth + 10;
-            }
-            context.SetData(new RoadsData(roads));
-        }
-
-        private void CreateRoad(IRoadTypeInfos typeid, List<Road> roads, ElevationGrid grid, Vector2 offset, List<City> places)
-        {
-            places.Add(new City(new TerrainPoint(256, 512) + offset, new List<TerrainPolygon>(), typeid.Id.ToString(), CityTypeId.Village, 256, 0));
-            CreateBridgePattern(typeid, roads, grid, 25, 128, new TerrainPoint(128, 128) + offset);
-            CreateBridgePattern(typeid, roads, grid, 25, 128, new TerrainPoint(128 + 256, 128) + offset, 20f);
-            CreateBridgePattern(typeid, roads, grid, 75, 256, new TerrainPoint(256, 385) + offset);
-            CreateBridgePattern(typeid, roads, grid, 75, 256, new TerrainPoint(256, 512 + 385) + offset, 20f);
-        }
-
-        private void CreateBridgePattern(IRoadTypeInfos typeid, List<Road> roads, ElevationGrid grid, int bridgeGap, int radius, TerrainPoint center, float centerElevation = 15f)
-        {
-            var centralRadius = 35;
-            var adjust = 5;
-
-            var min = center - new Vector2(radius);
-            var max = center + new Vector2(radius);
-            using (var mutate = grid.PrepareToMutate(min, max, 5, 25))
-            {
-                mutate.Image.Mutate(d =>
-                {
-                    d.Fill(new SolidBrush(mutate.ElevationToColor(10f)), new EllipsePolygon(mutate.ToPixel(center), MathF.Ceiling((centralRadius + bridgeGap - adjust) / grid.CellSize.X)));
-                    d.Fill(new SolidBrush(mutate.ElevationToColor(centerElevation)), new EllipsePolygon(mutate.ToPixel(center), MathF.Floor((centralRadius + adjust) / grid.CellSize.X)));
-                });
-                mutate.Apply();
-            }
-
-            // N --> S
-            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(0, radius), center + new Vector2(0, centralRadius + bridgeGap)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center + new Vector2(0, centralRadius + bridgeGap), center + new Vector2(0, centralRadius)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(0, centralRadius), center - new Vector2(0, centralRadius)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center - new Vector2(0, centralRadius), center - new Vector2(0, centralRadius + bridgeGap)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center - new Vector2(0, centralRadius + bridgeGap), center - new Vector2(0, radius)), typeid));
-
-            // W --> E
-            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(radius, 0), center + new Vector2(centralRadius + bridgeGap, 0)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center + new Vector2(centralRadius + bridgeGap, 0), center + new Vector2(centralRadius, 0)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(centralRadius, 0), center - new Vector2(centralRadius, 0)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center - new Vector2(centralRadius, 0), center - new Vector2(centralRadius + bridgeGap, 0)), typeid));
-            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center - new Vector2(centralRadius + bridgeGap, 0), center - new Vector2( radius, 0)), typeid));
-
-        }
-
-        private static void CreateSampleWatercourses(BuildContext context, List<City> places, Vector2 offset)
-        {
-            var river = new List<Watercourse>() { new Watercourse( new TerrainPath(
-                new TerrainPoint(64, 64)+offset,
-                new TerrainPoint(256, 64)+offset,
-                new TerrainPoint(448, 448)+offset
-                ), WatercourseTypeId.River) };
-
-            context.SetData(new WatercoursesData(river, river.SelectMany(r => r.Polygons).ToList()));
-            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Watercourses", CityTypeId.Village, 256, 0));
-        }
-
-        private static void CreateSampleLakes(BuildContext context, List<City> places, Vector2 offset)
-        {
-            context.SetData(new LakesData(new List<TerrainPolygon>() {
-                TerrainPolygon.FromRectangle(new TerrainPoint(128, 128) + offset, new TerrainPoint(128 + 256, 256) + offset),
-                TerrainPolygon.FromRectangle(new TerrainPoint(128, 320) + offset, new TerrainPoint(128 + 64, 384) + offset)
-            }));
-            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Lakes", CityTypeId.Village, 256, 0));
-        }
-
-        private void CreateSampleSingle<T>(BuildContext context, List<City> places, Func<List<TerrainPolygon>, T> value, Vector2 offset)
-            where T : class
-        {
-            var polygon = TerrainPolygon.FromRectangle(new TerrainPoint(28, 28)+ offset, new TerrainPoint(484, 484) + offset);
-            var polygons = new List<TerrainPolygon>() { polygon };
-            var center = new TerrainPoint(256, 256) + offset;
-            context.SetData<T>(value(polygons));
-            places.Add(new City(center, polygons, typeof(T).Name.Replace("Data", ""), CityTypeId.Village, 256, 0));
-        }
-
-        private void CreateSampleQuad<T>(BuildContext context, List<City> places, Func<List<TerrainPolygon>, T> value, Vector2 offset)
-            where T : class
-        {
-            var polygons = new List<TerrainPolygon>() {
-                TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(228, 228) + offset),
-                TerrainPolygon.FromRectangle(new TerrainPoint(28, 284) + offset, new TerrainPoint(228, 484) + offset),
-                TerrainPolygon.FromRectangle(new TerrainPoint(284, 28) + offset, new TerrainPoint(484, 228) + offset),
-                TerrainPolygon.FromRectangle(new TerrainPoint(284, 284) + offset, new TerrainPoint(484, 484) + offset)
-            };
-            var center = new TerrainPoint(256, 256) + offset;
-            context.SetData<T>(value(polygons));
-            places.Add(new City(center, polygons, typeof(T).Name.Replace("Data", ""), CityTypeId.Village, 256, 0));
-        }
         private Arma3MapConfig CreateConfig()
         {
             return new Arma3MapConfig(new Arma3MapConfigJson()

--- a/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
+++ b/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
@@ -1,10 +1,15 @@
-﻿using System.Runtime.Versioning;
+﻿using System.Numerics;
+using System.Runtime.Versioning;
 using BIS.WRP;
+using GameRealisticMap.Algorithms;
 using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.IO;
 using GameRealisticMap.Demo;
 using GameRealisticMap.ElevationModel;
+using GameRealisticMap.Geometries;
 using GameRealisticMap.ManMade.Buildings;
+using GameRealisticMap.ManMade.Places;
+using GameRealisticMap.ManMade.Roads;
 using GameRealisticMap.Osm;
 using GameRealisticMap.Reporting;
 using HugeImages.Storage;
@@ -13,6 +18,9 @@ namespace GameRealisticMap.Arma3
 {
     public class Arma3DemoMapGenerator : Arma3MapGenerator
     {
+        private static readonly string arrowModel = "A3\\Misc_F\\Helpers\\Sign_Arrow_Large_F.p3d";
+        private static readonly Vector3 arrowBoundingCenter = new Vector3(0, 0.75f, 0);
+
         private readonly string name;
         private readonly IDemoNaming demoNaming;
 
@@ -36,20 +44,136 @@ namespace GameRealisticMap.Arma3
 
             new DemoMapGenerator(assets.RoadTypeLibrary, demoNaming).CreateInto(context, name, buildingSizes);
 
+            var grid = context.GetData<ElevationData>().Elevation;
+            var places = context.GetData<CitiesData>().Cities;
+
+            var objects = new List<EditableWrpObject>();
+
+            BridgeAdjust(grid, places, objects);
+
+            BuildingAdjust(grid, places, objects);
+
+            context.SetData(objects);
+
             return context;
         }
+
+        private void BridgeAdjust(ElevationGrid grid, List<City> places, List<EditableWrpObject> objects)
+        {
+            var y = 1024f + 32f;
+            var x = 256f;
+            foreach (var id in Enum.GetValues<RoadTypeId>())
+            {
+                var roadType = assets.RoadTypeLibrary.GetInfo(id);
+                var bridge = assets.GetBridge(id);
+                if (bridge != null)
+                {
+                    var sx = x - roadType.ClearWidth * 4;
+
+                    AddBridgeSegment(grid, objects, roadType, new TerrainPoint(sx + roadType.ClearWidth, y), bridge.Start);
+                    sx += roadType.ClearWidth * 2;
+
+                    AddBridgeSegment(grid, objects, roadType, new TerrainPoint(sx + roadType.ClearWidth, y), bridge.Middle);
+                    sx += roadType.ClearWidth * 2;
+
+                    AddBridgeSegment(grid, objects, roadType, new TerrainPoint(sx + roadType.ClearWidth, y), bridge.End);
+                    sx += roadType.ClearWidth * 2;
+
+                    AddBridgeSegment(grid, objects, roadType, new TerrainPoint(sx + roadType.ClearWidth, y), bridge.Single);
+                }
+
+                x += 512;
+            }
+        }
+
+        private void BuildingAdjust(ElevationGrid grid, List<City> places, List<EditableWrpObject> objects)
+        {
+            var y = 4352f;
+            var x = 5f;
+            foreach (var id in Enum.GetValues<BuildingTypeId>())
+            {
+                var hasLabel = false;
+
+                foreach (var compo in assets.GetBuildings(id))
+                {
+                    if (!hasLabel)
+                    {
+                        places.Add(new City(new TerrainPoint(x + 1, y), new List<TerrainPolygon>(), demoNaming.GetBuildingName(id), CityTypeId.Village, 1, 0));
+                        hasLabel = true;
+                    }
+
+                    var center = new TerrainPoint(x + (compo.Size.X / 2), y);
+                    var pos = new ModelPosition(center, 0, 0, 1);
+                    objects.AddRange(compo.Composition.ToTerrainBuilderObjects(pos).Select(o => o.ToWrpObject(grid)));
+                    AddBuildingAdjustArrows(objects, center + new Vector2(+compo.Size.X / 2, +compo.Size.Y / 2));
+                    AddBuildingAdjustArrows(objects, center + new Vector2(-compo.Size.X / 2, +compo.Size.Y / 2));
+                    AddBuildingAdjustArrows(objects, center + new Vector2(+compo.Size.X / 2, -compo.Size.Y / 2));
+                    AddBuildingAdjustArrows(objects, center + new Vector2(-compo.Size.X / 2, -compo.Size.Y / 2));
+                    if (compo.Size.Y > 5)
+                    {
+                        AddBuildingAdjustArrows(objects, center + new Vector2(-compo.Size.X / 2, 0));
+                        AddBuildingAdjustArrows(objects, center + new Vector2(+compo.Size.X / 2, 0));
+                    }
+                    if (compo.Size.X > 5)
+                    {
+                        AddBuildingAdjustArrows(objects, center + new Vector2(0, -compo.Size.Y / 2));
+                        AddBuildingAdjustArrows(objects, center + new Vector2(0, +compo.Size.Y / 2));
+                    }
+                    x += compo.Size.X + 10;
+                }
+            }
+
+        }
+
 
         protected override IEnumerable<EditableWrpObject> GetObjects(IProgressTask progress, IArma3MapConfig config, IContext context, Arma3LayerGeneratorCatalog generators, ElevationGrid grid)
         {
             return base.GetObjects(progress, config, context, generators, grid)
-                .Concat(GetDemoObjects(config, context, grid));
+                .Concat(context.GetData<List<EditableWrpObject>>());
         }
 
-        private IEnumerable<EditableWrpObject> GetDemoObjects(IArma3MapConfig config, IContext context, ElevationGrid grid)
-        {
-            var objects = new List<EditableWrpObject>();
 
-            return objects;
+        private void AddBridgeSegment(ElevationGrid grid, List<EditableWrpObject> objects, Arma3RoadTypeInfos roadType, TerrainPoint center, StraightSegmentDefinition segment)
+        {
+            var pos = new ModelPosition(center, 0, 5, 1);
+            objects.AddRange(segment.Model.ToTerrainBuilderObjects(pos).Select(o => o.ToWrpObject(grid)));
+            AddBridgeAdjustArrows(objects,center + new Vector2( roadType.Width / 2, segment.Size / 2 ), 20f);
+            AddBridgeAdjustArrows(objects,center + new Vector2(-roadType.Width / 2, segment.Size / 2 ), 20f);
+            AddBridgeAdjustArrows(objects,center + new Vector2( roadType.Width / 2, -segment.Size / 2), 20f);
+            AddBridgeAdjustArrows(objects,center + new Vector2(-roadType.Width / 2, -segment.Size / 2), 20f);
+            AddBridgeAdjustArrows(objects,center + new Vector2(roadType.Width / 2, 0), 20f);
+            AddBridgeAdjustArrows(objects,center + new Vector2(-roadType.Width / 2, 0), 20f);
+        }
+
+        private EditableWrpObject CreateArrow(TerrainPoint terrainPoint, float elevation)
+        {
+            return new EditableWrpObject() { 
+                Model = arrowModel, 
+                Transform = new BIS.Core.Math.Matrix4P(Matrix4x4.CreateTranslation(new Vector3(terrainPoint.X, elevation, terrainPoint.Y) + arrowBoundingCenter)) 
+            };
+        }
+        private EditableWrpObject CreateReverseArrow(TerrainPoint terrainPoint, float elevation)
+        {
+            return new EditableWrpObject()
+            {
+                Model = arrowModel,
+                Transform = new BIS.Core.Math.Matrix4P(Matrix4x4.CreateTranslation(new Vector3(terrainPoint.X, elevation, terrainPoint.Y) + arrowBoundingCenter) * Matrix4x4.CreateRotationZ(MathF.PI, new Vector3(terrainPoint.X, elevation, terrainPoint.Y)))
+            };
+        }
+
+        private void AddBridgeAdjustArrows(List<EditableWrpObject> objects, TerrainPoint terrainPoint, float elevation)
+        {
+            objects.Add(CreateArrow(terrainPoint, elevation));
+            objects.Add(CreateReverseArrow(terrainPoint, elevation));
+            objects.Add(CreateArrow(terrainPoint, 15f)); // Ground
+        }
+
+        private void AddBuildingAdjustArrows(List<EditableWrpObject> objects, TerrainPoint terrainPoint)
+        {
+            objects.Add(CreateArrow(terrainPoint, 19.5f));
+            objects.Add(CreateArrow(terrainPoint, 18f));
+            objects.Add(CreateArrow(terrainPoint, 16.5f));
+            objects.Add(CreateArrow(terrainPoint, 15f)); // Ground
         }
 
         private Arma3MapConfig CreateConfig()

--- a/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
+++ b/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
@@ -165,7 +165,6 @@ namespace GameRealisticMap.Arma3
         {
             objects.Add(CreateArrow(terrainPoint, elevation));
             objects.Add(CreateReverseArrow(terrainPoint, elevation));
-            objects.Add(CreateArrow(terrainPoint, 15f)); // Ground
         }
 
         private void AddBuildingAdjustArrows(List<EditableWrpObject> objects, TerrainPoint terrainPoint)
@@ -173,7 +172,7 @@ namespace GameRealisticMap.Arma3
             objects.Add(CreateArrow(terrainPoint, 19.5f));
             objects.Add(CreateArrow(terrainPoint, 18f));
             objects.Add(CreateArrow(terrainPoint, 16.5f));
-            objects.Add(CreateArrow(terrainPoint, 15f)); // Ground
+            objects.Add(CreateArrow(terrainPoint, 15f));
         }
 
         private Arma3MapConfig CreateConfig()

--- a/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
+++ b/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
@@ -4,6 +4,7 @@ using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.IO;
 using GameRealisticMap.Demo;
 using GameRealisticMap.ElevationModel;
+using GameRealisticMap.ManMade.Buildings;
 using GameRealisticMap.Osm;
 using GameRealisticMap.Reporting;
 using HugeImages.Storage;
@@ -31,7 +32,9 @@ namespace GameRealisticMap.Arma3
         {
             var context = base.CreateBuildContext(progress, a3config, osmSource, hugeImageStorage);
 
-            new DemoMapGenerator(assets.RoadTypeLibrary, demoNaming).CreateInto(context, name);
+            var buildingSizes = Enum.GetValues<BuildingTypeId>().ToDictionary(id => id, id => assets.GetBuildings(id).Select(b => b.Size).ToList());
+
+            new DemoMapGenerator(assets.RoadTypeLibrary, demoNaming).CreateInto(context, name, buildingSizes);
 
             return context;
         }

--- a/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
+++ b/GameRealisticMap.Arma3/Arma3DemoMapGenerator.cs
@@ -1,0 +1,196 @@
+﻿using System.Numerics;
+using System.Runtime.Versioning;
+using GameRealisticMap.Arma3.Assets;
+using GameRealisticMap.Arma3.IO;
+using GameRealisticMap.ElevationModel;
+using GameRealisticMap.Geometries;
+using GameRealisticMap.ManMade;
+using GameRealisticMap.ManMade.Farmlands;
+using GameRealisticMap.ManMade.Places;
+using GameRealisticMap.ManMade.Roads;
+using GameRealisticMap.ManMade.Roads.Libraries;
+using GameRealisticMap.Nature.Forests;
+using GameRealisticMap.Nature.Lakes;
+using GameRealisticMap.Nature.RockAreas;
+using GameRealisticMap.Nature.Scrubs;
+using GameRealisticMap.Nature.Surfaces;
+using GameRealisticMap.Nature.Watercourses;
+using GameRealisticMap.Osm;
+using GameRealisticMap.Reporting;
+using HugeImages.Storage;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Processing;
+
+namespace GameRealisticMap.Arma3
+{
+    public class Arma3DemoMapGenerator : Arma3MapGenerator
+    {
+        private readonly string name;
+
+        public Arma3DemoMapGenerator(IArma3RegionAssets assets, ProjectDrive projectDrive, string name)
+            : base(assets, projectDrive)
+        {
+            this.name = name;
+        }
+
+        protected override Task<IOsmDataSource> LoadOsmData(IProgressTask progress, Arma3MapConfig a3config)
+        {
+            return Task.FromResult<IOsmDataSource>(new NoneOsmDataSource());
+        }
+
+        protected override BuildContext CreateBuildContext(IProgressTask progress, Arma3MapConfig a3config, IOsmDataSource osmSource, IHugeImageStorage? hugeImageStorage = null)
+        {
+            var context = base.CreateBuildContext(progress, a3config, osmSource, hugeImageStorage);
+
+            var grid = new ElevationGrid(a3config.TerrainArea.GridSize, a3config.TerrainArea.GridCellSize);
+            grid.Fill(15f);
+            context.SetData(new RawElevationData(grid));
+
+            var places = new List<City>();
+
+            CreateSampleSingle(context, places, polygon => new ForestData(polygon), new Vector2(0 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new ScrubData(polygon), new Vector2(1 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new RocksData(polygon), new Vector2(2 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new GrassData(polygon), new Vector2(3 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new MeadowsData(polygon), new Vector2(4 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new SandSurfacesData(polygon), new Vector2(5 * 512, 0));
+            CreateSampleQuad(context, places, polygon => new FarmlandsData(polygon), new Vector2(0 * 512, 512));
+            CreateSampleLakes(context, places, new Vector2(6 * 512, 0));
+            CreateSampleWatercourses(context, places, new Vector2(7 * 512, 0));
+
+            places.Add(new City(new TerrainPoint(a3config.TerrainArea.SizeInMeters / 2, a3config.TerrainArea.SizeInMeters / 2), new List<TerrainPolygon>() { a3config.TerrainArea.TerrainBounds }, name + " DEMO", CityTypeId.City, 1024, 10000));
+            context.SetData(new CitiesData(places));
+
+            CreateRoads(context,grid);
+
+            return context;
+        }
+
+        private void CreateRoads(BuildContext context, ElevationGrid grid)
+        {
+            var roads = new List<Road>();
+            int index = 0;
+            foreach(var typeid in Enum.GetValues<RoadTypeId>())
+            {
+                CreateRoad(assets.RoadTypeLibrary.GetInfo(typeid), roads, grid, new Vector2(index * 512, 1024));
+                index++;
+            }
+            context.SetData(new RoadsData(roads));
+        }
+
+        private void CreateRoad(IRoadTypeInfos typeid, List<Road> roads, ElevationGrid grid, Vector2 offset)
+        {
+            CreateBridgePattern(typeid, roads, grid, 25, 128, new TerrainPoint(128, 128) + offset);
+            CreateBridgePattern(typeid, roads, grid, 25, 128, new TerrainPoint(128 + 256, 128) + offset, 20f);
+            CreateBridgePattern(typeid, roads, grid, 75, 256, new TerrainPoint(256, 385) + offset);
+            CreateBridgePattern(typeid, roads, grid, 75, 256, new TerrainPoint(256, 512 + 385) + offset, 20f);
+        }
+
+        private void CreateBridgePattern(IRoadTypeInfos typeid, List<Road> roads, ElevationGrid grid, int bridgeGap, int radius, TerrainPoint center, float centerElevation = 15f)
+        {
+            var centralRadius = 35;
+            var adjust = 5;
+
+            var min = center - new Vector2(radius);
+            var max = center + new Vector2(radius);
+            using (var mutate = grid.PrepareToMutate(min, max, 5, 25))
+            {
+                mutate.Image.Mutate(d =>
+                {
+                    d.Fill(new SolidBrush(mutate.ElevationToColor(10f)), new EllipsePolygon(mutate.ToPixel(center), MathF.Ceiling((centralRadius + bridgeGap - adjust) / grid.CellSize.X)));
+                    d.Fill(new SolidBrush(mutate.ElevationToColor(centerElevation)), new EllipsePolygon(mutate.ToPixel(center), MathF.Floor((centralRadius + adjust) / grid.CellSize.X)));
+                });
+                mutate.Apply();
+            }
+
+            // N --> S
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(0, radius), center + new Vector2(0, centralRadius + bridgeGap)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center + new Vector2(0, centralRadius + bridgeGap), center + new Vector2(0, centralRadius)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(0, centralRadius), center - new Vector2(0, centralRadius)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center - new Vector2(0, centralRadius), center - new Vector2(0, centralRadius + bridgeGap)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center - new Vector2(0, centralRadius + bridgeGap), center - new Vector2(0, radius)), typeid));
+
+            // W --> E
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(radius, 0), center + new Vector2(centralRadius + bridgeGap, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center + new Vector2(centralRadius + bridgeGap, 0), center + new Vector2(centralRadius, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(centralRadius, 0), center - new Vector2(centralRadius, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center - new Vector2(centralRadius, 0), center - new Vector2(centralRadius + bridgeGap, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center - new Vector2(centralRadius + bridgeGap, 0), center - new Vector2( radius, 0)), typeid));
+
+        }
+
+        private static void CreateSampleWatercourses(BuildContext context, List<City> places, Vector2 offset)
+        {
+            var river = new List<Watercourse>() { new Watercourse( new TerrainPath(
+                new TerrainPoint(64, 64)+offset,
+                new TerrainPoint(256, 64)+offset,
+                new TerrainPoint(448, 448)+offset
+                ), WatercourseTypeId.River) };
+
+            context.SetData(new WatercoursesData(river, river.SelectMany(r => r.Polygons).ToList()));
+            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Watercourses", CityTypeId.Village, 256, 0));
+        }
+
+        private static void CreateSampleLakes(BuildContext context, List<City> places, Vector2 offset)
+        {
+            context.SetData(new LakesData(new List<TerrainPolygon>() {
+                TerrainPolygon.FromRectangle(new TerrainPoint(128, 128) + offset, new TerrainPoint(128 + 256, 256) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(128, 320) + offset, new TerrainPoint(128 + 64, 384) + offset)
+            }));
+            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Lakes", CityTypeId.Village, 256, 0));
+        }
+
+        private void CreateSampleSingle<T>(BuildContext context, List<City> places, Func<List<TerrainPolygon>, T> value, Vector2 offset)
+            where T : class
+        {
+            var polygon = TerrainPolygon.FromRectangle(new TerrainPoint(28, 28)+ offset, new TerrainPoint(484, 484) + offset);
+            var polygons = new List<TerrainPolygon>() { polygon };
+            var center = new TerrainPoint(256, 256) + offset;
+            context.SetData<T>(value(polygons));
+            places.Add(new City(center, polygons, typeof(T).Name.Replace("Data", ""), CityTypeId.Village, 256, 0));
+        }
+
+        private void CreateSampleQuad<T>(BuildContext context, List<City> places, Func<List<TerrainPolygon>, T> value, Vector2 offset)
+            where T : class
+        {
+            var polygons = new List<TerrainPolygon>() {
+                TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(228, 228) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(28, 284) + offset, new TerrainPoint(228, 484) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(284, 28) + offset, new TerrainPoint(484, 228) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(284, 284) + offset, new TerrainPoint(484, 484) + offset)
+            };
+            var center = new TerrainPoint(256, 256) + offset;
+            context.SetData<T>(value(polygons));
+            places.Add(new City(center, polygons, typeof(T).Name.Replace("Data", ""), CityTypeId.Village, 256, 0));
+        }
+        private Arma3MapConfig CreateConfig()
+        {
+            return new Arma3MapConfig(new Arma3MapConfigJson()
+            {
+                WorldName = $"grm_demo_{name}",
+                GridSize = 1024,
+                GridCellSize = 5,
+                FakeSatBlend = 1,
+                SouthWest = "0, 0",
+                Resolution = 1,
+                TileSize = 512
+            });
+        }
+
+        public async Task<Arma3MapConfig> GenerateWrp(IProgressTask progress)
+        {
+            var config = CreateConfig();
+            await GenerateWrp(progress, config);
+            return config;
+        }
+
+        [SupportedOSPlatform("windows")]
+        public async Task<Arma3MapConfig> GenerateMod(IProgressTask progress)
+        {
+            var config = CreateConfig();
+            await GenerateMod(progress, config);
+            return config;
+        }
+    }
+}

--- a/GameRealisticMap.Arma3/Arma3MapGenerator.cs
+++ b/GameRealisticMap.Arma3/Arma3MapGenerator.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Runtime.Versioning;
+﻿using System.Runtime.Versioning;
 using BIS.WRP;
 using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.GameEngine;
@@ -16,7 +15,7 @@ namespace GameRealisticMap.Arma3
 {
     public class Arma3MapGenerator
     {
-        private readonly IArma3RegionAssets assets;
+        protected readonly IArma3RegionAssets assets;
         private readonly ProjectDrive projectDrive;
 
         public Arma3MapGenerator(IArma3RegionAssets assets, ProjectDrive projectDrive)
@@ -37,12 +36,16 @@ namespace GameRealisticMap.Arma3
 
         public async Task<IBuildContext?> GetBuildContext(IProgressTask progress, Arma3MapConfig a3config, IHugeImageStorage hugeImageStorage)
         {
-            var loader = new OsmDataOverPassLoader(progress);
-            var osmSource = await loader.Load(a3config.TerrainArea);
+            var osmSource = await LoadOsmData(progress, a3config);
             if (progress.CancellationToken.IsCancellationRequested)
             {
                 return null;
             }
+            return CreateBuildContext(progress, a3config, osmSource, hugeImageStorage);
+        }
+
+        protected virtual BuildContext CreateBuildContext(IProgressTask progress, Arma3MapConfig a3config, IOsmDataSource osmSource, IHugeImageStorage? hugeImageStorage = null)
+        {
             var builders = new BuildersCatalog(progress, assets.RoadTypeLibrary);
             return new BuildContext(builders, progress, a3config.TerrainArea, osmSource, a3config.Imagery, hugeImageStorage);
         }
@@ -81,8 +84,7 @@ namespace GameRealisticMap.Arma3
             progress.Total += 6 + generators.Generators.Count;
 
             // Download from OSM
-            var loader = new OsmDataOverPassLoader(progress);
-            var osmSource = await loader.Load(a3config.TerrainArea);
+            var osmSource = await LoadOsmData(progress, a3config);
             progress.ReportOneDone();
             if (progress.CancellationToken.IsCancellationRequested)
             {
@@ -90,9 +92,8 @@ namespace GameRealisticMap.Arma3
             }
 
             // Generate content
-            var builders = new BuildersCatalog(progress, assets.RoadTypeLibrary);
-            var context = new BuildContext(builders, progress, a3config.TerrainArea, osmSource, a3config.Imagery);
-            GenerateWrp(progress, a3config, context, a3config.TerrainArea, generators); 
+            var context = CreateBuildContext(progress, a3config, osmSource);
+            GenerateWrp(progress, a3config, context, a3config.TerrainArea, generators);
             context.DisposeHugeImages();
             if (progress.CancellationToken.IsCancellationRequested)
             {
@@ -104,6 +105,12 @@ namespace GameRealisticMap.Arma3
             progress.ReportOneDone();
 
             return context;
+        }
+
+        protected virtual async Task<IOsmDataSource> LoadOsmData(IProgressTask progress, Arma3MapConfig a3config)
+        {
+            var loader = new OsmDataOverPassLoader(progress);
+            return await loader.Load(a3config.TerrainArea);
         }
 
         public void GenerateWrp(IProgressTask progress, IArma3MapConfig config, IContext context, ITerrainArea area, Arma3LayerGeneratorCatalog generators)

--- a/GameRealisticMap.Arma3/Arma3MapGenerator.cs
+++ b/GameRealisticMap.Arma3/Arma3MapGenerator.cs
@@ -145,16 +145,21 @@ namespace GameRealisticMap.Arma3
 
             var size = area.SizeInMeters;
 
-            var objects = generators.Generators
-                .Progress(progress)
-                .SelectMany(tb => tb.Generate(config, context))
-                .Select(o => o.ToWrpObject(grid))
+            var objects = GetObjects(progress, config, context, generators, grid)
                 .Where(o => IsStrictlyInside(o, size));
 
             wrpBuilder.Write(config, grid, tiles, objects);
             progress.ReportOneDone();
 
             UnpackFiles(progress, GetRequiredFiles(wrpBuilder));
+        }
+
+        protected virtual IEnumerable<EditableWrpObject> GetObjects(IProgressTask progress, IArma3MapConfig config, IContext context, Arma3LayerGeneratorCatalog generators, ElevationGrid grid)
+        {
+            return generators.Generators
+                            .Progress(progress)
+                            .SelectMany(tb => tb.Generate(config, context))
+                            .Select(o => o.ToWrpObject(grid));
         }
 
         private List<string> GetRequiredFiles(WrpCompiler wrpBuilder)

--- a/GameRealisticMap.Arma3/Assets/IArma3RegionAssets.cs
+++ b/GameRealisticMap.Arma3/Assets/IArma3RegionAssets.cs
@@ -19,7 +19,7 @@ namespace GameRealisticMap.Arma3.Assets
         string BaseDependency { get; }
 
         IReadOnlyCollection<BuildingDefinition> GetBuildings(BuildingTypeId buildingTypeId);
-
+        
         IReadOnlyCollection<ObjectDefinition> GetObjects(ObjectTypeId typeId);
 
         IReadOnlyCollection<BasicCollectionDefinition> GetBasicCollections(BasicCollectionId basicId);

--- a/GameRealisticMap.Arma3/Builtin/CentralEurope.grma3a
+++ b/GameRealisticMap.Arma3/Builtin/CentralEurope.grma3a
@@ -595,44 +595,44 @@
           "Objects": [
             {
               "Model": "a3\\structures_f\\bridges\\Bridge_HighWay_F.p3d",
-              "Transform": [0.0008945465,-3.3085892,0.07499981]
+              "Transform": [0.0008945465,-3.258589,0.07499981]
             }
           ]
         },
-        "Size": 44.2501
+        "Size": 40
       },
       "Start": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Concrete_02_right_F.p3d",
-              "Transform": [0.02676344,-3.3171349,-0.6463604]
+              "Transform": [0.02676344,-3.2671347,-1.6]
             }
           ]
         },
-        "Size": 22.1788
+        "Size": 19.8
       },
       "Middle": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Concrete_02_center_F.p3d",
-              "Transform": [0.03502512,-3.8190699,0.09825897]
+              "Transform": [0.03502512,-3.7690697,-0.05]
             }
           ]
         },
-        "Size": 40.636
+        "Size": 40.3
       },
       "End": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Concrete_02_left_F.p3d",
-              "Transform": [0.0008945465,-3.308694,0.9323082]
+              "Transform": [0.0008945465,-3.2586937,1.49]
             }
           ]
         },
-        "Size": 22.1291
+        "Size": 20
       }
     },
     "TwoLanesPrimaryRoad": {
@@ -641,44 +641,44 @@
           "Objects": [
             {
               "Model": "a3\\structures_f\\bridges\\Bridge_HighWay_F.p3d",
-              "Transform": [0.0008945465,-3.3085892,0.07499981]
+              "Transform": [0.0008945465,-3.258589,0.07499981]
             }
           ]
         },
-        "Size": 44.2501
+        "Size": 40
       },
       "Start": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Concrete_02_right_F.p3d",
-              "Transform": [0.02676344,-3.3171349,-0.6463604]
+              "Transform": [0.02676344,-3.2671347,-1.6]
             }
           ]
         },
-        "Size": 22.1788
+        "Size": 19.8
       },
       "Middle": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Concrete_02_center_F.p3d",
-              "Transform": [0.03502512,-3.8190699,0.09825897]
+              "Transform": [0.03502512,-3.7690697,-0.05]
             }
           ]
         },
-        "Size": 40.636
+        "Size": 40.3
       },
       "End": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Concrete_02_left_F.p3d",
-              "Transform": [0.0008945465,-3.308694,0.9323082]
+              "Transform": [0.0008945465,-3.2586937,1.49]
             }
           ]
         },
-        "Size": 22.1291
+        "Size": 20
       }
     },
     "TwoLanesSecondaryRoad": {
@@ -687,44 +687,44 @@
           "Objects": [
             {
               "Model": "a3\\structures_f\\bridges\\Bridge_Asphalt_F.p3d",
-              "Transform": [0.02192235,-3.0325508,0.52775955]
+              "Transform": [0.02192235,-3.0075507,0.52775955]
             }
           ]
         },
-        "Size": 44.2341
+        "Size": 42
       },
       "Start": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Asphalt_02_right_F.p3d",
-              "Transform": [-0.018576622,-3.0320826,2.369604]
+              "Transform": [-0.018576622,-3.0070825,-1.25]
             }
           ]
         },
-        "Size": 30.213799
+        "Size": 28
       },
       "Middle": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Asphalt_02_center_F.p3d",
-              "Transform": [0.004999876,-3.0320814,-0.005074024]
+              "Transform": [0.004999876,-3.0070813,-0.005074024]
             }
           ]
         },
-        "Size": 24.2894
+        "Size": 24
       },
       "End": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Asphalt_02_left_F.p3d",
-              "Transform": [0.021921158,-3.0320845,-2.154234]
+              "Transform": [0.021921158,-3.0070844,1.25]
             }
           ]
         },
-        "Size": 30.2295
+        "Size": 28
       }
     },
     "TwoLanesConcreteRoad": {
@@ -733,44 +733,44 @@
           "Objects": [
             {
               "Model": "a3\\structures_f\\bridges\\Bridge_Concrete_F.p3d",
-              "Transform": [-0.005653143,-3.0325508,0.52775955]
+              "Transform": [-0.005653143,-3.0075507,0.52775955]
             }
           ]
         },
-        "Size": 44.2341
+        "Size": 42
       },
       "Start": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Asphalt_02_right_F.p3d",
-              "Transform": [-0.018576622,-3.0320826,2.369604]
+              "Transform": [-0.018576622,-3.0070825,-1.25]
             }
           ]
         },
-        "Size": 30.213799
+        "Size": 28
       },
       "Middle": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Asphalt_02_center_F.p3d",
-              "Transform": [0.004999876,-3.0320814,-0.005074024]
+              "Transform": [0.004999876,-3.0070813,-0.005074024]
             }
           ]
         },
-        "Size": 24.2894
+        "Size": 24
       },
       "End": {
         "Model": {
           "Objects": [
             {
               "Model": "a3\\structures_f_enoch\\infrastructure\\Bridges\\Bridge_Asphalt_02_left_F.p3d",
-              "Transform": [0.021921158,-3.0320845,-2.154234]
+              "Transform": [0.021921158,-3.0070844,1.25]
             }
           ]
         },
-        "Size": 30.2295
+        "Size": 28
       }
     }
   },

--- a/GameRealisticMap.Arma3/GameEngine/RoadsCompiler.cs
+++ b/GameRealisticMap.Arma3/GameEngine/RoadsCompiler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.IO;
-using GameRealisticMap.Geometries;
 using GameRealisticMap.ManMade;
 using GameRealisticMap.ManMade.Roads;
 using GameRealisticMap.ManMade.Roads.Libraries;
@@ -44,7 +43,7 @@ namespace GameRealisticMap.Arma3.GameEngine
                     continue;
                 }
                 var attributesTable = new AttributesTable();
-                attributesTable.Add("ID", ((int)road.RoadType)+1);
+                attributesTable.Add("ID", ((int)road.RoadType) + 1);
                 var path = road.Path;
                 if (road.RoadType < RoadTypeId.SingleLaneDirtPath)
                 {
@@ -54,11 +53,24 @@ namespace GameRealisticMap.Arma3.GameEngine
             }
             var shapeWriter = new ShapefileDataWriter(new ShapeFileWriter(fileSystemWriter, $"{config.PboPrefix}\\data\\roads\\roads"), new GeometryFactory(), Encoding.ASCII)
             {
-                Header = ShapefileDataWriter.GetHeader(features.First(), features.Count, Encoding.ASCII)
+                Header = GetHeader(features)
             };
             shapeWriter.Write(features);
         }
 
+        private static DbaseFileHeader GetHeader(List<Feature> features)
+        {
+            if (features.Count == 0)
+            {
+                DbaseFileHeader dbaseFileHeader = new DbaseFileHeader(Encoding.ASCII)
+                {
+                    NumRecords = features.Count
+                };
+                dbaseFileHeader.AddColumn("ID", 'N', 10, 0);
+                return dbaseFileHeader;
+            }
+            return ShapefileDataWriter.GetHeader(features.First(), features.Count, Encoding.ASCII);
+        }
 
         private void WriteRoadsLibCgf(IArma3MapConfig config)
         {

--- a/GameRealisticMap.Arma3/GameEngine/RoadsCompiler.cs
+++ b/GameRealisticMap.Arma3/GameEngine/RoadsCompiler.cs
@@ -44,6 +44,7 @@ namespace GameRealisticMap.Arma3.GameEngine
                 }
                 var attributesTable = new AttributesTable();
                 attributesTable.Add("ID", ((int)road.RoadType) + 1);
+                attributesTable.Add("ORDER", ((int)road.RoadType) + 1);
                 var path = road.Path;
                 if (road.RoadType < RoadTypeId.SingleLaneDirtPath)
                 {

--- a/GameRealisticMap.Arma3/GameLauncher/Arma3LauncherHelper.cs
+++ b/GameRealisticMap.Arma3/GameLauncher/Arma3LauncherHelper.cs
@@ -1,0 +1,47 @@
+﻿using System.Text.Json;
+using System.Xml.Linq;
+using GameRealisticMap.Arma3.Assets;
+
+namespace GameRealisticMap.Arma3.GameLauncher
+{
+    public static class Arma3LauncherHelper
+    {
+        public static async Task CreateLauncherPresetAsync(List<ModDependencyDefinition> dependencies, string localModpath, string presetName)
+        {
+            // Ensure that local mod is registred within launcher
+            Arma3LauncherLocalMods mods;
+            var local = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Arma 3 Launcher", "Local.json");
+            if (File.Exists(local))
+            {
+                using (var stream = File.OpenRead(local))
+                {
+                    mods = (await JsonSerializer.DeserializeAsync<Arma3LauncherLocalMods>(stream))!;
+                }
+                if (!mods.knownLocalMods.Contains(localModpath, StringComparer.OrdinalIgnoreCase))
+                {
+                    mods.knownLocalMods.Add(localModpath);
+                    mods.userDirectories.Add(localModpath);
+                    using (var stream = File.Create(local))
+                    {
+                        await JsonSerializer.SerializeAsync(stream, mods);
+                    }
+                }
+            }
+
+            // Create a ready-to-use preset
+            var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Arma 3 Launcher", "Presets");
+            var preset = Path.Combine(directory, presetName + ".preset2");
+            if (!File.Exists(preset))
+            {
+                var doc = new XDocument(new XElement("addons-presets",
+                    new XElement("last-update", DateTime.Now),
+                    new XElement("published-ids",
+                        dependencies.Select(d => new XElement("id", "steam:" + d.SteamId))
+                        .Concat(new[] { new XElement("id", "local:" + localModpath.ToUpperInvariant().TrimEnd('\\') + "\\") })),
+                    new XElement("dlcs-appids")));
+                Directory.CreateDirectory(directory);
+                doc.Save(preset);
+            }
+        }
+    }
+}

--- a/GameRealisticMap.Arma3/GameLauncher/Arma3LauncherLocalMods.cs
+++ b/GameRealisticMap.Arma3/GameLauncher/Arma3LauncherLocalMods.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace GameRealisticMap.Studio.Modules.MapConfigEditor.ViewModels
+﻿namespace GameRealisticMap.Arma3.GameLauncher
 {
     public class Arma3LauncherLocalMods
     {

--- a/GameRealisticMap.Arma3/Imagery/SatMapRender.cs
+++ b/GameRealisticMap.Arma3/Imagery/SatMapRender.cs
@@ -38,7 +38,16 @@ namespace GameRealisticMap.Arma3.Imagery
 
         public Image RenderPictureMap(IArma3MapConfig config, IContext context, int size)
         {
-            var satMap = context.GetData<RawSatelliteImageData>().Image;
+            HugeImage<Rgba32> satMap;
+
+            if (config.FakeSatBlend == 1)
+            {
+                satMap = RenderBaseImageAsync(config, context).GetAwaiter().GetResult();
+            }
+            else
+            {
+                satMap = context.GetData<RawSatelliteImageData>().Image;
+            }
 
             // TODO: Add shadows based on elevation data
 

--- a/GameRealisticMap.Arma3/ManMade/BridgeGenerator.cs
+++ b/GameRealisticMap.Arma3/ManMade/BridgeGenerator.cs
@@ -66,7 +66,7 @@ namespace GameRealisticMap.Arma3.ManMade
 
             objects.AddRange(definition.Start.Model.ToTerrainBuilderObjects(
                 new TerrainPoint(Vector2.Lerp(path.FirstPoint.Vector, path.LastPoint.Vector, stDelta)),
-                elevationStart + ((elevationEnd - elevationStart) * (1f - stDelta)),
+                elevationStart + ((elevationEnd - elevationStart) * (stDelta)),
                 angle,
                 pitch));
 
@@ -78,7 +78,7 @@ namespace GameRealisticMap.Arma3.ManMade
 
             objects.AddRange(definition.End.Model.ToTerrainBuilderObjects(
                 new TerrainPoint(Vector2.Lerp(path.FirstPoint.Vector, path.LastPoint.Vector, endDelta)),
-                elevationStart + ((elevationEnd - elevationStart) * (1f - endDelta)),
+                elevationStart + ((elevationEnd - elevationStart) * (endDelta)),
                 angle,
                 pitch));
         }

--- a/GameRealisticMap.Arma3/TerrainBuilder/ModelPreviewHelper.cs
+++ b/GameRealisticMap.Arma3/TerrainBuilder/ModelPreviewHelper.cs
@@ -38,7 +38,15 @@ namespace GameRealisticMap.Arma3.TerrainBuilder
         {
             return ToPolygons(GetOrCreate(cacheVisual, obj.Model, GetVisualLod), obj.ToWrpTransform(), ZProjection.Instance);
         }
+        public IEnumerable<TerrainPolygon> ToGeoAxisX(TerrainBuilderObject obj)
+        {
+            return ToPolygons(GetOrCreate(cacheGeo, obj.Model, GetGeoLod), obj.ToWrpTransform(), XProjection.Instance);
+        }
 
+        public IEnumerable<TerrainPolygon> ToVisualAxisX(TerrainBuilderObject obj)
+        {
+            return ToPolygons(GetOrCreate(cacheVisual, obj.Model, GetVisualLod), obj.ToWrpTransform(), XProjection.Instance);
+        }
         private IEnumerable<TerrainPolygon> ToPolygons(List<TerrainPolygon> terrainPolygons, Matrix4x4 matrix, I3dProjection projection)
         {
             return terrainPolygons.Select(p => Transform(p, matrix, projection));

--- a/GameRealisticMap.Arma3/TerrainBuilder/XProjection.cs
+++ b/GameRealisticMap.Arma3/TerrainBuilder/XProjection.cs
@@ -1,0 +1,22 @@
+﻿using System.Numerics;
+using GameRealisticMap.Geometries;
+
+namespace GameRealisticMap.Arma3.TerrainBuilder
+{
+    internal sealed class XProjection : I3dProjection
+    {
+        internal static readonly XProjection Instance = new XProjection();
+
+        private XProjection() { }
+
+        public TerrainPoint Project(Vector3 p)
+        {
+            return new TerrainPoint(p.Z, p.Y);
+        }
+
+        public Vector3 Unproject(TerrainPoint p)
+        {
+            return new Vector3(0, p.Y, p.X);
+        }
+    }
+}

--- a/GameRealisticMap.Studio/Labels.Designer.cs
+++ b/GameRealisticMap.Studio/Labels.Designer.cs
@@ -1303,11 +1303,38 @@ namespace GameRealisticMap.Studio {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Generate a demo map.
+        /// </summary>
+        public static string GenerateADemoWorld {
+            get {
+                return ResourceManager.GetString("GenerateADemoWorld", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Generate areas only (faster).
         /// </summary>
         public static string GenerateAreasOnly {
             get {
                 return ResourceManager.GetString("GenerateAreasOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Generate a mod (ready-to-use).
+        /// </summary>
+        public static string GenerateDemoMod {
+            get {
+                return ResourceManager.GetString("GenerateDemoMod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Generate a map (wrp file).
+        /// </summary>
+        public static string GenerateDemoWrpFile {
+            get {
+                return ResourceManager.GetString("GenerateDemoWrpFile", resourceCulture);
             }
         }
         

--- a/GameRealisticMap.Studio/Labels.Designer.cs
+++ b/GameRealisticMap.Studio/Labels.Designer.cs
@@ -1294,6 +1294,15 @@ namespace GameRealisticMap.Studio {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Forest.
+        /// </summary>
+        public static string Forest {
+            get {
+                return ResourceManager.GetString("Forest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à ✔ Found.
         /// </summary>
         public static string Found {
@@ -1551,6 +1560,15 @@ namespace GameRealisticMap.Studio {
         public static string Label {
             get {
                 return ResourceManager.GetString("Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Lakes.
+        /// </summary>
+        public static string Lakes {
+            get {
+                return ResourceManager.GetString("Lakes", resourceCulture);
             }
         }
         
@@ -2157,6 +2175,15 @@ namespace GameRealisticMap.Studio {
         public static string WarnRecommanded {
             get {
                 return ResourceManager.GetString("WarnRecommanded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Watercourses.
+        /// </summary>
+        public static string Watercourses {
+            get {
+                return ResourceManager.GetString("Watercourses", resourceCulture);
             }
         }
         

--- a/GameRealisticMap.Studio/Labels.fr.resx
+++ b/GameRealisticMap.Studio/Labels.fr.resx
@@ -831,4 +831,13 @@ Vous pouvez éventuellement activer d'autres mods.</value>
   <data name="GenerateDemoWrpFile" xml:space="preserve">
     <value>Générer une carte (fichier wrp)</value>
   </data>
+  <data name="Forest" xml:space="preserve">
+    <value>Forêt</value>
+  </data>
+  <data name="Lakes" xml:space="preserve">
+    <value>Lacs</value>
+  </data>
+  <data name="Watercourses" xml:space="preserve">
+    <value>Cours d'eau</value>
+  </data>
 </root>

--- a/GameRealisticMap.Studio/Labels.fr.resx
+++ b/GameRealisticMap.Studio/Labels.fr.resx
@@ -822,4 +822,13 @@ Vous pouvez éventuellement activer d'autres mods.</value>
   <data name="Close" xml:space="preserve">
     <value>Fermer</value>
   </data>
+  <data name="GenerateADemoWorld" xml:space="preserve">
+    <value>Générer une carte de démonstration</value>
+  </data>
+  <data name="GenerateDemoMod" xml:space="preserve">
+    <value>Générer un mod (prêt à l'emploi)</value>
+  </data>
+  <data name="GenerateDemoWrpFile" xml:space="preserve">
+    <value>Générer une carte (fichier wrp)</value>
+  </data>
 </root>

--- a/GameRealisticMap.Studio/Labels.resx
+++ b/GameRealisticMap.Studio/Labels.resx
@@ -831,4 +831,13 @@ You may eventually enable other mods.</value>
   <data name="GenerateDemoMod" xml:space="preserve">
     <value>Generate a mod (ready-to-use)</value>
   </data>
+  <data name="Forest" xml:space="preserve">
+    <value>Forest</value>
+  </data>
+  <data name="Lakes" xml:space="preserve">
+    <value>Lakes</value>
+  </data>
+  <data name="Watercourses" xml:space="preserve">
+    <value>Watercourses</value>
+  </data>
 </root>

--- a/GameRealisticMap.Studio/Labels.resx
+++ b/GameRealisticMap.Studio/Labels.resx
@@ -822,4 +822,13 @@ You may eventually enable other mods.</value>
   <data name="Close" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="GenerateADemoWorld" xml:space="preserve">
+    <value>Generate a demo map</value>
+  </data>
+  <data name="GenerateDemoWrpFile" xml:space="preserve">
+    <value>Generate a map (wrp file)</value>
+  </data>
+  <data name="GenerateDemoMod" xml:space="preserve">
+    <value>Generate a mod (ready-to-use)</value>
+  </data>
 </root>

--- a/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/AssetConfigEditorViewModel.cs
+++ b/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/AssetConfigEditorViewModel.cs
@@ -416,7 +416,7 @@ namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
         {
             var name = Path.GetFileNameWithoutExtension(FileName);
             var assets = ToJson();
-            var generator = new Arma3DemoMapGenerator(ToJson(), _arma3Data.ProjectDrive, name);
+            var generator = new Arma3DemoMapGenerator(ToJson(), _arma3Data.ProjectDrive, name, new StudioDemoNaming());
             var config = await generator.GenerateMod(task);
             if (config != null)
             {

--- a/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/AssetConfigEditorViewModel.cs
+++ b/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/AssetConfigEditorViewModel.cs
@@ -6,8 +6,10 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Caliburn.Micro;
+using GameRealisticMap.Arma3;
 using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.Assets.Filling;
+using GameRealisticMap.Arma3.GameLauncher;
 using GameRealisticMap.Arma3.IO;
 using GameRealisticMap.ManMade.Buildings;
 using GameRealisticMap.ManMade.Fences;
@@ -21,6 +23,7 @@ using GameRealisticMap.Studio.Modules.CompositionTool;
 using GameRealisticMap.Studio.Modules.CompositionTool.ViewModels;
 using GameRealisticMap.Studio.Modules.Explorer;
 using GameRealisticMap.Studio.Modules.Explorer.ViewModels;
+using GameRealisticMap.Studio.Modules.Reporting;
 using GameRealisticMap.Studio.Toolkit;
 using GameRealisticMap.Studio.UndoRedo;
 using Gemini.Framework;
@@ -392,6 +395,34 @@ namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
                 NotifyOfPropertyChange(nameof(MissingMods));
 
                 await DoLoad(FilePath);
+            }
+        }
+
+        public Task GenerateDemoMod()
+        {
+            Arma3ToolsHelper.EnsureProjectDrive();
+
+            IoC.Get<IProgressTool>()
+                .RunTask(Labels.GenerateDemoMod, DoGenerateMod);
+
+            return Task.CompletedTask;
+        }
+        public Task GenerateDemoWrp()
+        {
+            return Task.CompletedTask;
+        }
+
+        private async Task DoGenerateMod(IProgressTaskUI task)
+        {
+            var name = Path.GetFileNameWithoutExtension(FileName);
+            var assets = ToJson();
+            var generator = new Arma3DemoMapGenerator(ToJson(), _arma3Data.ProjectDrive, name);
+            var config = await generator.GenerateMod(task);
+            if (config != null)
+            {
+                task.AddSuccessAction(() => ShellHelper.OpenUri(config.TargetModDirectory), Labels.ViewInFileExplorer);
+                task.AddSuccessAction(() => ShellHelper.OpenUri("steam://run/107410"), Labels.OpenArma3Launcher, string.Format(Labels.OpenArma3LauncherWithGeneratedModHint, name));
+                await Arma3LauncherHelper.CreateLauncherPresetAsync(assets.Dependencies, config.TargetModDirectory, "GRM - " + name);
             }
         }
     }

--- a/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/AssetConfigEditorViewModel.cs
+++ b/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/AssetConfigEditorViewModel.cs
@@ -407,8 +407,12 @@ namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
 
             return Task.CompletedTask;
         }
+
         public Task GenerateDemoWrp()
         {
+            IoC.Get<IProgressTool>()
+                .RunTask(Labels.GenerateDemoWrpFile, DoGenerateWrp);
+
             return Task.CompletedTask;
         }
 
@@ -423,6 +427,18 @@ namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
                 task.AddSuccessAction(() => ShellHelper.OpenUri(config.TargetModDirectory), Labels.ViewInFileExplorer);
                 task.AddSuccessAction(() => ShellHelper.OpenUri("steam://run/107410"), Labels.OpenArma3Launcher, string.Format(Labels.OpenArma3LauncherWithGeneratedModHint, name));
                 await Arma3LauncherHelper.CreateLauncherPresetAsync(assets.Dependencies, config.TargetModDirectory, "GRM - " + name);
+            }
+        }
+
+        private async Task DoGenerateWrp(IProgressTaskUI task)
+        {
+            var name = Path.GetFileNameWithoutExtension(FileName);
+            var assets = ToJson();
+            var generator = new Arma3DemoMapGenerator(ToJson(), _arma3Data.ProjectDrive, name, new StudioDemoNaming());
+            var config = await generator.GenerateWrp(task);
+            if (config != null)
+            {
+                task.AddSuccessAction(() => ShellHelper.OpenUri(_arma3Data.ProjectDrive.GetFullPath(config.PboPrefix)), Labels.ViewInFileExplorer);;
             }
         }
     }

--- a/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/StudioDemoNaming.cs
+++ b/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/StudioDemoNaming.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using GameRealisticMap.Demo;
 using GameRealisticMap.ManMade.Buildings;
+using GameRealisticMap.ManMade.Farmlands;
 using GameRealisticMap.ManMade.Fences;
 using GameRealisticMap.ManMade.Objects;
 using GameRealisticMap.ManMade.Roads;
 using GameRealisticMap.Nature.Forests;
+using GameRealisticMap.Nature.Lakes;
 using GameRealisticMap.Nature.RockAreas;
+using GameRealisticMap.Nature.Scrubs;
 using GameRealisticMap.Nature.Surfaces;
+using GameRealisticMap.Nature.Watercourses;
 
 namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
 {
@@ -51,7 +55,7 @@ namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
         {
             if ( type == typeof(ForestData))
             {
-                return Labels.AssetForest;
+                return Labels.Forest;
             }
             if (type == typeof(MeadowsData))
             {
@@ -65,7 +69,26 @@ namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
             {
                 return Labels.AssetRocks;
             }
-            // ...
+            if (type == typeof(GrassData))
+            {
+                return Labels.AssetGrass;
+            }
+            if (type == typeof(LakesData))
+            {
+                return Labels.Lakes;
+            }
+            if (type == typeof(WatercoursesData))
+            {
+                return Labels.Watercourses;
+            }
+            if (type == typeof(FarmlandsData))
+            {
+                return Labels.AssetFarmLand;
+            }
+            if (type == typeof(ScrubData))
+            {
+                return Labels.AssetScrub;
+            }
             return type.Name.Replace("Data", "");
         }
     }

--- a/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/StudioDemoNaming.cs
+++ b/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/StudioDemoNaming.cs
@@ -12,6 +12,12 @@ namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
 {
     internal class StudioDemoNaming : IDemoNaming
     {
+        public string GetBuildingName(BuildingTypeId id)
+        {
+            var idText = id.ToString();
+            return Labels.ResourceManager.GetString("Asset" + idText) ?? idText;
+        }
+
         public string GetFenceName(FenceTypeId id)
         {
             var idText = id.ToString();

--- a/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/StudioDemoNaming.cs
+++ b/GameRealisticMap.Studio/Modules/AssetConfigEditor/ViewModels/StudioDemoNaming.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using GameRealisticMap.Demo;
+using GameRealisticMap.ManMade.Buildings;
+using GameRealisticMap.ManMade.Fences;
+using GameRealisticMap.ManMade.Objects;
+using GameRealisticMap.ManMade.Roads;
+using GameRealisticMap.Nature.Forests;
+using GameRealisticMap.Nature.RockAreas;
+using GameRealisticMap.Nature.Surfaces;
+
+namespace GameRealisticMap.Studio.Modules.AssetConfigEditor.ViewModels
+{
+    internal class StudioDemoNaming : IDemoNaming
+    {
+        public string GetFenceName(FenceTypeId id)
+        {
+            var idText = id.ToString();
+            return Labels.ResourceManager.GetString("Asset" + idText) ?? idText;
+        }
+
+        public string GetObjectName(ObjectTypeId id)
+        {
+            var idText = id.ToString();
+            return Labels.ResourceManager.GetString("Asset" + idText) ?? idText;
+        }
+
+        public string GetRoadName(RoadTypeId id)
+        {
+            var idText = id.ToString();
+            return Labels.ResourceManager.GetString("Asset" + idText) ?? idText;
+        }
+
+        public string GetSurfaceName(BuildingTypeId id)
+        {
+            switch(id)
+            {
+                case BuildingTypeId.Industrial:
+                    return Labels.AssetDefaultIndustrial;
+                default:
+                    return Labels.AssetDefaultUrban;
+            }
+        }
+
+        public string GetSurfaceName(Type type)
+        {
+            if ( type == typeof(ForestData))
+            {
+                return Labels.AssetForest;
+            }
+            if (type == typeof(MeadowsData))
+            {
+                return Labels.AssetMeadow;
+            }
+            if (type == typeof(SandSurfacesData))
+            {
+                return Labels.AssetSand;
+            }
+            if (type == typeof(RocksData))
+            {
+                return Labels.AssetRocks;
+            }
+            // ...
+            return type.Name.Replace("Data", "");
+        }
+    }
+}

--- a/GameRealisticMap.Studio/Modules/AssetConfigEditor/Views/AssetConfigEditorView.xaml
+++ b/GameRealisticMap.Studio/Modules/AssetConfigEditor/Views/AssetConfigEditorView.xaml
@@ -26,8 +26,10 @@
                                    <Run Text="{x:Static r:Labels.Help}" />
                                 </Hyperlink>
                     </TextBlock>
+
                 </StackPanel>
 
+                
                 <Border Margin="10" Padding="10" BorderBrush="Red" BorderThickness="2" Visibility="{Binding HasMissingMods, Converter={StaticResource BooleanToVisibilityConverter}}" >
                     <StackPanel>
                         <TextBlock FontSize="20" Foreground="Red"><Run Text="{x:Static r:Labels.SomeModsAreMissing}"/></TextBlock>
@@ -47,6 +49,18 @@
                     </StackPanel>
                 </Border>
 
+                <StackPanel Margin="0 5" Orientation="Horizontal">
+                    <Button Margin="10 0" Padding="10" b:ButtonBehaviors.OpenContextOnClick="True">
+                        <Run Text="{x:Static r:Labels.GenerateADemoWorld}" />
+                        <Button.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="{x:Static r:Labels.GenerateDemoWrpFile}" cal:Message.Attach="GenerateDemoWrp"></MenuItem>
+                                <MenuItem Header="{x:Static r:Labels.GenerateDemoMod}" cal:Message.Attach="GenerateDemoMod"></MenuItem>
+                            </ContextMenu>
+                        </Button.ContextMenu>
+                    </Button>
+                </StackPanel>
+                
                 <StackPanel Orientation="Horizontal" Margin="10 0" Visibility="{Binding CanCopyFrom, Converter={StaticResource BooleanToVisibilityConverter}}">
 
                     <TextBlock VerticalAlignment="Center" FontSize="15"><Run Text="{x:Static r:Labels.QuickStartFrom}"/></TextBlock>

--- a/GameRealisticMap.Studio/Modules/CompositionTool/ViewModels/CompositionItem.cs
+++ b/GameRealisticMap.Studio/Modules/CompositionTool/ViewModels/CompositionItem.cs
@@ -76,6 +76,8 @@ namespace GameRealisticMap.Studio.Modules.CompositionTool.ViewModels
             NotifyOfPropertyChange(nameof(PreviewVisualAxisY));
             NotifyOfPropertyChange(nameof(PreviewGeoAxisZ));
             NotifyOfPropertyChange(nameof(PreviewVisualAxisZ));
+            NotifyOfPropertyChange(nameof(PreviewGeoAxisX));
+            NotifyOfPropertyChange(nameof(PreviewVisualAxisX));
         }
 
         public string PreviewGeoAxisY
@@ -93,6 +95,7 @@ namespace GameRealisticMap.Studio.Modules.CompositionTool.ViewModels
                 return ToPath(IoC.Get<IArma3DataModule>().ModelPreviewHelper.ToVisualAxisY(ToTerrainBuilderObject()));
             }
         }
+
         public string PreviewGeoAxisZ
         {
             get
@@ -106,6 +109,23 @@ namespace GameRealisticMap.Studio.Modules.CompositionTool.ViewModels
             get
             {
                 return ToPath(IoC.Get<IArma3DataModule>().ModelPreviewHelper.ToVisualAxisZ(ToTerrainBuilderObject()));
+            }
+        }
+
+
+        public string PreviewGeoAxisX
+        {
+            get
+            {
+                return ToPath(IoC.Get<IArma3DataModule>().ModelPreviewHelper.ToGeoAxisX(ToTerrainBuilderObject()));
+            }
+        }
+
+        public string PreviewVisualAxisX
+        {
+            get
+            {
+                return ToPath(IoC.Get<IArma3DataModule>().ModelPreviewHelper.ToVisualAxisX(ToTerrainBuilderObject()));
             }
         }
         private static string ToPath(IEnumerable<TerrainPolygon> polygons)

--- a/GameRealisticMap.Studio/Modules/CompositionTool/Views/CompositionToolView.xaml
+++ b/GameRealisticMap.Studio/Modules/CompositionTool/Views/CompositionToolView.xaml
@@ -81,7 +81,7 @@
 
             <TabItem>
                 <TabItem.Header>
-                    Side view
+                    Front view
                 </TabItem.Header>
                 <Border ClipToBounds="True">
                     <local:ZoomBorder Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" VerticalAlignment="Center" HorizontalAlignment="Center" Background="LightGray">
@@ -137,6 +137,64 @@
                 </Border>
             </TabItem>
 
+            <TabItem>
+                <TabItem.Header>
+                    Side view
+                </TabItem.Header>
+                <Border ClipToBounds="True">
+                    <local:ZoomBorder Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" VerticalAlignment="Center" HorizontalAlignment="Center" Background="LightGray">
+                        <Grid Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" ClipToBounds="False"  VerticalAlignment="Center" HorizontalAlignment="Center">
+                            <local:CanvasWithGrid Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" Background="LightGray" VerticalAlignment="Center" HorizontalAlignment="Center">
+                            </local:CanvasWithGrid>
+                            <ItemsControl ItemsSource="{Binding Composition.Items}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <Canvas Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Path Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" Data="{Binding PreviewVisualAxisX}" Fill="Gray" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <ItemsControl ItemsSource="{Binding Composition.Items}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <Canvas Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Path Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" Data="{Binding PreviewGeoAxisX}" Fill="Black" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <Canvas Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                <Line X1="0" X2="{x:Static local:CanvasGrid.Size}" Y1="{x:Static local:CanvasGrid.HalfSize}" Y2="{x:Static local:CanvasGrid.HalfSize}"  Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" Stroke="Red" StrokeThickness="1" />
+                                <Line X1="{x:Static local:CanvasGrid.HalfSize}" X2="{x:Static local:CanvasGrid.HalfSize}" Y1="0" Y2="{x:Static local:CanvasGrid.Size}"  Width="{x:Static local:CanvasGrid.Size}" Height="{x:Static local:CanvasGrid.Size}" Stroke="Red" StrokeThickness="1" />
+                            </Canvas>
+                            <Rectangle 
+                        Width="{Binding Radius.FitRadius, Converter={StaticResource MetersToPixelsConverterX2}}" 
+                       Height="{x:Static local:CanvasGrid.Size}"
+                        Visibility="{Binding HasRadius, Converter={StaticResource BoolToVisibilityConverter}}" 
+                        StrokeThickness="1" Stroke="#8000FF00" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            <Rectangle 
+                        Width="{Binding Radius.Radius, Converter={StaticResource MetersToPixelsConverterX2}}" 
+                        Height="{x:Static local:CanvasGrid.Size}"
+                        Visibility="{Binding HasRadius, Converter={StaticResource BoolToVisibilityConverter}}"
+                        StrokeThickness="1" Stroke="#800000FF" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            <Rectangle 
+                        Width="{Binding Rectangle.Depth, Converter={StaticResource MetersToPixelsConverter}}" 
+                        Height="{x:Static local:CanvasGrid.Size}"
+                        Visibility="{Binding HasRectangle, Converter={StaticResource BoolToVisibilityConverter}}" 
+                        StrokeThickness="2" Stroke="#800000FF" VerticalAlignment="Center" HorizontalAlignment="Center" ClipToBounds="False" />
+
+                        </Grid>
+                    </local:ZoomBorder>
+                </Border>
+            </TabItem>
+            
         </TabControl>
 
         <DataGrid Grid.Row="2" ItemsSource="{Binding Composition.Items}" AutoGenerateColumns="false" local2:Behaviors.UndoRedoManager="{Binding UndoRedoManager}">

--- a/GameRealisticMap.Test/Geometries/TerrainPathTest.cs
+++ b/GameRealisticMap.Test/Geometries/TerrainPathTest.cs
@@ -92,5 +92,19 @@ namespace GameRealisticMap.Test.Geometries
                 new TerrainPoint(20,20)
             }, 2));
         }
+
+        [Fact]
+        public void TerrainPath_ExtendBothEnds()
+        {
+            var path = new TerrainPath(new(0, 0), new(0, 10), new(10, 10));
+            var pathEx = path.ExtendBothEnds(5);
+            Assert.Equal(30, pathEx.Length);
+            Assert.Equal(new TerrainPoint[] { new(0, -5), new(0, 10), new(15, 10) }, pathEx.Points);
+
+            path = new TerrainPath(new(0, 5), new(0, 15));
+            pathEx = path.ExtendBothEnds(5);
+            Assert.Equal(20, pathEx.Length);
+            Assert.Equal(new TerrainPoint[] { new(0, 0), new(0, 20) }, pathEx.Points);
+        }
     }
 }

--- a/GameRealisticMap/BuildContext.cs
+++ b/GameRealisticMap/BuildContext.cs
@@ -51,5 +51,11 @@ namespace GameRealisticMap
                 return builtData;
             }
         }
+
+        public void SetData<T>(T value)
+            where T : class
+        {
+            datas[typeof(T)] = value;
+        }
     }
 }

--- a/GameRealisticMap/Demo/DefaultDemoNaming.cs
+++ b/GameRealisticMap/Demo/DefaultDemoNaming.cs
@@ -7,6 +7,11 @@ namespace GameRealisticMap.Demo
 {
     public class DefaultDemoNaming : IDemoNaming
     {
+        public string GetBuildingName(BuildingTypeId id)
+        {
+            return id.ToString();
+        }
+
         public string GetFenceName(FenceTypeId id)
         {
             return id.ToString();

--- a/GameRealisticMap/Demo/DefaultDemoNaming.cs
+++ b/GameRealisticMap/Demo/DefaultDemoNaming.cs
@@ -1,0 +1,35 @@
+﻿using GameRealisticMap.ManMade.Buildings;
+using GameRealisticMap.ManMade.Fences;
+using GameRealisticMap.ManMade.Objects;
+using GameRealisticMap.ManMade.Roads;
+
+namespace GameRealisticMap.Demo
+{
+    public class DefaultDemoNaming : IDemoNaming
+    {
+        public string GetFenceName(FenceTypeId id)
+        {
+            return id.ToString();
+        }
+
+        public string GetObjectName(ObjectTypeId id)
+        {
+            return id.ToString();
+        }
+
+        public string GetRoadName(RoadTypeId id)
+        {
+            return id.ToString();
+        }
+
+        public string GetSurfaceName(BuildingTypeId id)
+        {
+            return id.ToString();
+        }
+
+        public string GetSurfaceName(Type type)
+        {
+            return type.Name.Replace("Data", "");
+        }
+    }
+}

--- a/GameRealisticMap/Demo/DemoMapGenerator.cs
+++ b/GameRealisticMap/Demo/DemoMapGenerator.cs
@@ -90,9 +90,7 @@ namespace GameRealisticMap.Demo
         {
             var buildings = new List<Building>();
 
-            // 3072 + 128
-
-            var centerY = 2048 + 512f;
+            var centerY = 2048 + 412f;
             var x = 0f;
 
             var secondary = roadTypeLibrary.GetInfo(RoadTypeId.TwoLanesSecondaryRoad);
@@ -112,7 +110,7 @@ namespace GameRealisticMap.Demo
                     if (x + patternSize > area.SizeInMeters)
                     {
                         x = 0;
-                        centerY += 512f;
+                        centerY += 412f;
                         mainRoad = new Road(WaySpecialSegment.Normal, new TerrainPath(new(0, centerY), new(area.SizeInMeters, centerY)), secondary);
                         roads.Add(mainRoad);
                         hasLabel = false;
@@ -126,7 +124,7 @@ namespace GameRealisticMap.Demo
 
                     var centerX = x + (patternSize / 2);
 
-                    var perroad = new Road(WaySpecialSegment.Normal, new TerrainPath(new(centerX, centerY - 256), new(centerX, centerY + 256)), tertiary);
+                    var perroad = new Road(WaySpecialSegment.Normal, new TerrainPath(new(centerX, centerY - 206), new(centerX, centerY + 206)), tertiary);
                     roads.Add(perroad);
 
                     var shiftX = size.X / 2 + tertiary.ClearWidth / 2 + 8;
@@ -137,7 +135,7 @@ namespace GameRealisticMap.Demo
                     AddRoad(buildings, mainRoad, id, perroad, new BoundingBox(new TerrainPoint(centerX + shiftX, centerY + shiftY), size.X, size.Y, 0));
 
                     shiftX = size.Y / 2 + tertiary.ClearWidth / 2 + 1;
-                    shiftY = 128;
+                    shiftY = 103;
                     AddRoad(buildings, mainRoad, id, perroad, new BoundingBox(new TerrainPoint(centerX - shiftX, centerY - shiftY), size.Y, size.X, 0));
                     AddRoad(buildings, mainRoad, id, perroad, new BoundingBox(new TerrainPoint(centerX + shiftX, centerY - shiftY), size.Y, size.X, 0));
                     AddRoad(buildings, mainRoad, id, perroad, new BoundingBox(new TerrainPoint(centerX - shiftX, centerY + shiftY), size.Y, size.X, 0));
@@ -301,7 +299,7 @@ namespace GameRealisticMap.Demo
 
         }
 
-        private static void CreateSampleWatercourses(BuildContext context, List<City> places, Vector2 offset)
+        private void CreateSampleWatercourses(BuildContext context, List<City> places, Vector2 offset)
         {
             var river = new List<Watercourse>() { new Watercourse( new TerrainPath(
                 new TerrainPoint(64, 64)+offset,
@@ -310,16 +308,16 @@ namespace GameRealisticMap.Demo
                 ), WatercourseTypeId.River) };
 
             context.SetData(new WatercoursesData(river, river.SelectMany(r => r.Polygons).ToList()));
-            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Watercourses", CityTypeId.Village, 256, 0));
+            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, demoNaming.GetSurfaceName(typeof(WatercoursesData)), CityTypeId.Village, 256, 0));
         }
 
-        private static void CreateSampleLakes(BuildContext context, List<City> places, Vector2 offset)
+        private void CreateSampleLakes(BuildContext context, List<City> places, Vector2 offset)
         {
             context.SetData(new LakesData(new List<TerrainPolygon>() {
                 TerrainPolygon.FromRectangle(new TerrainPoint(128, 128) + offset, new TerrainPoint(128 + 256, 256) + offset),
                 TerrainPolygon.FromRectangle(new TerrainPoint(128, 320) + offset, new TerrainPoint(128 + 64, 384) + offset)
             }));
-            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Lakes", CityTypeId.Village, 256, 0));
+            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, demoNaming.GetSurfaceName(typeof(LakesData)), CityTypeId.Village, 256, 0));
         }
 
         private void CreateSampleSingle<T>(BuildContext context, List<City> places, Func<List<TerrainPolygon>, T> value, Vector2 offset)

--- a/GameRealisticMap/Demo/DemoMapGenerator.cs
+++ b/GameRealisticMap/Demo/DemoMapGenerator.cs
@@ -1,0 +1,270 @@
+﻿using System.Numerics;
+using GameRealisticMap.ElevationModel;
+using GameRealisticMap.Geometries;
+using GameRealisticMap.ManMade;
+using GameRealisticMap.ManMade.Buildings;
+using GameRealisticMap.ManMade.Farmlands;
+using GameRealisticMap.ManMade.Fences;
+using GameRealisticMap.ManMade.Objects;
+using GameRealisticMap.ManMade.Places;
+using GameRealisticMap.ManMade.Roads;
+using GameRealisticMap.ManMade.Roads.Libraries;
+using GameRealisticMap.Nature.Forests;
+using GameRealisticMap.Nature.Lakes;
+using GameRealisticMap.Nature.RockAreas;
+using GameRealisticMap.Nature.Scrubs;
+using GameRealisticMap.Nature.Surfaces;
+using GameRealisticMap.Nature.Watercourses;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Processing;
+
+namespace GameRealisticMap.Demo
+{
+    /// <summary>
+    /// Generate a simple world to show case all features of a map generator.
+    /// 
+    /// This can be useful to debug a specific game engine generator, or to show case a specific configuration.
+    /// </summary>
+    public class DemoMapGenerator
+    {
+        private readonly IRoadTypeLibrary<IRoadTypeInfos> roadTypeLibrary;
+        private readonly IDemoNaming demoNaming;
+
+        public DemoMapGenerator(IRoadTypeLibrary<IRoadTypeInfos> roadTypeLibrary, IDemoNaming demoNaming)
+        {
+            this.roadTypeLibrary = roadTypeLibrary;
+            this.demoNaming = demoNaming;
+        }
+
+        public void CreateInto(BuildContext context, string name)
+        {
+
+            var grid = new ElevationGrid(context.Area.GridSize, context.Area.GridCellSize);
+            grid.Fill(15f);
+            context.SetData(new RawElevationData(grid));
+
+            var places = new List<City>();
+
+            CreateSampleSingle(context, places, polygon => new ForestData(polygon), new Vector2(0 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new ScrubData(polygon), new Vector2(1 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new RocksData(polygon), new Vector2(2 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new GrassData(polygon), new Vector2(3 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new MeadowsData(polygon), new Vector2(4 * 512, 0));
+            CreateSampleSingle(context, places, polygon => new SandSurfacesData(polygon), new Vector2(5 * 512, 0));
+            CreateSampleQuad(context, places, polygon => new FarmlandsData(polygon), new Vector2(0 * 512, 512));
+            CreateSampleLakes(context, places, new Vector2(6 * 512, 0));
+            CreateSampleWatercourses(context, places, new Vector2(7 * 512, 0));
+            context.SetData(new CategoryAreaData(
+                new List<CategoryArea>()
+                {
+                   new CategoryArea(BuildingTypeId.Residential, CreateSquare512(places, demoNaming.GetSurfaceName(BuildingTypeId.Residential), new Vector2(1 * 512, 512))),
+                   new CategoryArea(BuildingTypeId.Industrial, CreateSquare512(places, demoNaming.GetSurfaceName(BuildingTypeId.Industrial), new Vector2(2 * 512, 512)))
+               }));
+
+
+            CreateSampleFences(context, places);
+
+            var roads = CreateSampleRoads(grid, places);
+
+            CreateSampleOriented(context, roads, places);
+
+            places.Add(new City(new TerrainPoint(context.Area.SizeInMeters / 2, context.Area.SizeInMeters / 2), new List<TerrainPolygon>() { context.Area.TerrainBounds }, name + " DEMO", CityTypeId.City, 1024, 10000));
+
+            context.SetData(new RoadsData(roads));
+            context.SetData(new CitiesData(places));
+        }
+
+        private void CreateSampleOriented(BuildContext context, List<Road> roads, List<City> places)
+        {
+            var offset = new Vector2(4 * 512, 512);
+            var suboffset = new Vector2(0, 0);
+
+            var objects = new List<OrientedObject>();
+            foreach (var obj in Enum.GetValues<ObjectTypeId>())
+            {
+                CreateSampleOriented(objects, roads, places, obj, offset + suboffset);
+                suboffset.X += 102;
+                if (suboffset.X >= 410)
+                {
+                    suboffset.Y += 102;
+                    suboffset.X = 0;
+                }
+            }
+            context.SetData(new OrientedObjectData(objects));
+        }
+
+
+        private void CreateSampleOriented(List<OrientedObject> objects, List<Road> roads, List<City> places, ObjectTypeId id, Vector2 offset)
+        {
+            var type = roadTypeLibrary.GetInfo(RoadTypeId.TwoLanesConcreteRoad);
+            var margin = (type.ClearWidth / 2) + 2;
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(new TerrainPoint(0, 51) + offset, new TerrainPoint(102, 51) + offset), type));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(new TerrainPoint(51, 0) + offset, new TerrainPoint(51, 102) + offset), type));
+            places.Add(new City(new TerrainPoint(51, 51) + offset, new List<TerrainPolygon>(), demoNaming.GetObjectName(id), CityTypeId.Village, 51, 0));
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 - margin, 51 - margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 - margin, 51 + margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 + margin, 51 - margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 + margin, 51 + margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(17, 51 - margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(17, 51 + margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(34, 51 - margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(34, 51 + margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(68, 51 - margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(68, 51 + margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(85, 51 - margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(85, 51 + margin) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 - margin, 17) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 + margin, 17) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 - margin, 34) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 + margin, 34) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 - margin, 68) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 + margin, 68) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 - margin, 85) + offset);
+            AddSampleObject(objects, roads, id, new TerrainPoint(51 + margin, 85) + offset);
+        }
+
+        private static void AddSampleObject(List<OrientedObject> objects, List<Road> roads, ObjectTypeId id, TerrainPoint p)
+        {
+            objects.Add(new OrientedObject(p, GeometryHelper.GetFacing(p, roads.Select(r => r.Path), 50) ?? 0, id));
+        }
+
+        private void CreateSampleFences(BuildContext context, List<City> places)
+        {
+            var fences = new List<Fence>();
+            var offset = new Vector2(3 * 512, 512);
+            CreateSampleFence(places, fences, offset, FenceTypeId.Fence);
+            CreateSampleFence(places, fences, offset + new Vector2(120, 0), FenceTypeId.Hedge);
+            CreateSampleFence(places, fences, offset + new Vector2(240, 0), FenceTypeId.Wall);
+            context.SetData(new FencesData(fences));
+        }
+
+        private void CreateSampleFence(List<City> places, List<Fence> fences, Vector2 offset, FenceTypeId id)
+        {
+            fences.Add(new Fence(TerrainPath.FromRectangle(new TerrainPoint(8, 8) + offset, new TerrainPoint(18, 18) + offset), id));
+            fences.Add(new Fence(TerrainPath.FromRectangle(new TerrainPoint(8, 22) + offset, new TerrainPoint(28, 42) + offset), id));
+            fences.Add(new Fence(TerrainPath.FromRectangle(new TerrainPoint(8, 46) + offset, new TerrainPoint(48, 86) + offset), id));
+
+            fences.Add(new Fence(TerrainPath.FromCircle(new TerrainPoint(78, 13) + offset, 5), id));
+            fences.Add(new Fence(TerrainPath.FromCircle(new TerrainPoint(78, 32) + offset, 10), id));
+            fences.Add(new Fence(TerrainPath.FromCircle(new TerrainPoint(78, 66) + offset, 20), id));
+
+            fences.Add(new Fence(TerrainPath.FromCircle(new TerrainPoint(52, 150) + offset, 50), id));
+
+            places.Add(new City(new TerrainPoint(52, 45) + offset, new List<TerrainPolygon>(), demoNaming.GetFenceName(id), CityTypeId.Village, 52, 0));
+        }
+
+        private List<Road> CreateSampleRoads(ElevationGrid grid, List<City> places)
+        {
+            var roads = new List<Road>();
+            int index = 0;
+            foreach (var typeid in Enum.GetValues<RoadTypeId>())
+            {
+                CreateRoad(roadTypeLibrary.GetInfo(typeid), roads, grid, new Vector2(index * 512, 1024), places);
+                index++;
+            }
+            var y = 1024f + 518f;
+            foreach (var typeid in Enum.GetValues<RoadTypeId>())
+            {
+                var type = roadTypeLibrary.GetInfo(typeid);
+
+                roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(new(0, y), new(5120, y)), type));
+
+                y += type.ClearWidth + 10;
+            }
+
+            return roads;
+        }
+
+        private void CreateRoad(IRoadTypeInfos typeid, List<Road> roads, ElevationGrid grid, Vector2 offset, List<City> places)
+        {
+            places.Add(new City(new TerrainPoint(256, 128) + offset, new List<TerrainPolygon>(), demoNaming.GetRoadName(typeid.Id), CityTypeId.Village, 256, 0));
+            CreateBridgePattern(typeid, roads, grid, 25, 128, new TerrainPoint(128, 128) + offset);
+            CreateBridgePattern(typeid, roads, grid, 25, 128, new TerrainPoint(128 + 256, 128) + offset, 20f);
+            CreateBridgePattern(typeid, roads, grid, 75, 256, new TerrainPoint(256, 385) + offset);
+            CreateBridgePattern(typeid, roads, grid, 75, 256, new TerrainPoint(256, 512 + 385) + offset, 20f);
+        }
+
+        private void CreateBridgePattern(IRoadTypeInfos typeid, List<Road> roads, ElevationGrid grid, int bridgeGap, int radius, TerrainPoint center, float centerElevation = 15f)
+        {
+            var centralRadius = 35;
+            var adjust = 5;
+
+            var min = center - new Vector2(radius);
+            var max = center + new Vector2(radius);
+            using (var mutate = grid.PrepareToMutate(min, max, 5, 25))
+            {
+                mutate.Image.Mutate(d =>
+                {
+                    d.Fill(new SolidBrush(mutate.ElevationToColor(10f)), new EllipsePolygon(mutate.ToPixel(center), MathF.Ceiling((centralRadius + bridgeGap - adjust) / grid.CellSize.X)));
+                    d.Fill(new SolidBrush(mutate.ElevationToColor(centerElevation)), new EllipsePolygon(mutate.ToPixel(center), MathF.Floor((centralRadius + adjust) / grid.CellSize.X)));
+                });
+                mutate.Apply();
+            }
+
+            // N --> S
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(0, radius), center + new Vector2(0, centralRadius + bridgeGap)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center + new Vector2(0, centralRadius + bridgeGap), center + new Vector2(0, centralRadius)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(0, centralRadius), center - new Vector2(0, centralRadius)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center - new Vector2(0, centralRadius), center - new Vector2(0, centralRadius + bridgeGap)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center - new Vector2(0, centralRadius + bridgeGap), center - new Vector2(0, radius)), typeid));
+
+            // W --> E
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(radius, 0), center + new Vector2(centralRadius + bridgeGap, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center + new Vector2(centralRadius + bridgeGap, 0), center + new Vector2(centralRadius, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center + new Vector2(centralRadius, 0), center - new Vector2(centralRadius, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Bridge, new TerrainPath(center - new Vector2(centralRadius, 0), center - new Vector2(centralRadius + bridgeGap, 0)), typeid));
+            roads.Add(new Road(WaySpecialSegment.Normal, new TerrainPath(center - new Vector2(centralRadius + bridgeGap, 0), center - new Vector2(radius, 0)), typeid));
+
+        }
+
+        private static void CreateSampleWatercourses(BuildContext context, List<City> places, Vector2 offset)
+        {
+            var river = new List<Watercourse>() { new Watercourse( new TerrainPath(
+                new TerrainPoint(64, 64)+offset,
+                new TerrainPoint(256, 64)+offset,
+                new TerrainPoint(448, 448)+offset
+                ), WatercourseTypeId.River) };
+
+            context.SetData(new WatercoursesData(river, river.SelectMany(r => r.Polygons).ToList()));
+            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Watercourses", CityTypeId.Village, 256, 0));
+        }
+
+        private static void CreateSampleLakes(BuildContext context, List<City> places, Vector2 offset)
+        {
+            context.SetData(new LakesData(new List<TerrainPolygon>() {
+                TerrainPolygon.FromRectangle(new TerrainPoint(128, 128) + offset, new TerrainPoint(128 + 256, 256) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(128, 320) + offset, new TerrainPoint(128 + 64, 384) + offset)
+            }));
+            places.Add(new City(new TerrainPoint(256, 256) + offset, new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) }, "Lakes", CityTypeId.Village, 256, 0));
+        }
+
+        private void CreateSampleSingle<T>(BuildContext context, List<City> places, Func<List<TerrainPolygon>, T> value, Vector2 offset)
+            where T : class
+        {
+            context.SetData<T>(value(CreateSquare512(places, demoNaming.GetSurfaceName(typeof(T)), offset)));
+        }
+
+        private List<TerrainPolygon> CreateSquare512(List<City> places, string name, Vector2 offset)
+        {
+            var polygons = new List<TerrainPolygon>() { TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(484, 484) + offset) };
+            var center = new TerrainPoint(256, 256) + offset;
+            places.Add(new City(center, polygons, name, CityTypeId.Village, 256, 0));
+            return polygons;
+        }
+
+        private void CreateSampleQuad<T>(BuildContext context, List<City> places, Func<List<TerrainPolygon>, T> value, Vector2 offset)
+            where T : class
+        {
+            var polygons = new List<TerrainPolygon>() {
+                TerrainPolygon.FromRectangle(new TerrainPoint(28, 28) + offset, new TerrainPoint(228, 228) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(28, 284) + offset, new TerrainPoint(228, 484) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(284, 28) + offset, new TerrainPoint(484, 228) + offset),
+                TerrainPolygon.FromRectangle(new TerrainPoint(284, 284) + offset, new TerrainPoint(484, 484) + offset)
+            };
+            var center = new TerrainPoint(256, 256) + offset;
+            context.SetData<T>(value(polygons));
+            places.Add(new City(center, polygons, demoNaming.GetSurfaceName(typeof(T)), CityTypeId.Village, 256, 0));
+        }
+    }
+}

--- a/GameRealisticMap/Demo/IDemoNaming.cs
+++ b/GameRealisticMap/Demo/IDemoNaming.cs
@@ -7,6 +7,7 @@ namespace GameRealisticMap.Demo
 {
     public interface IDemoNaming
     {
+        string GetBuildingName(BuildingTypeId id);
         string GetFenceName(FenceTypeId id);
         string GetObjectName(ObjectTypeId id);
         string GetRoadName(RoadTypeId id);

--- a/GameRealisticMap/Demo/IDemoNaming.cs
+++ b/GameRealisticMap/Demo/IDemoNaming.cs
@@ -1,0 +1,16 @@
+﻿using GameRealisticMap.ManMade.Buildings;
+using GameRealisticMap.ManMade.Fences;
+using GameRealisticMap.ManMade.Objects;
+using GameRealisticMap.ManMade.Roads;
+
+namespace GameRealisticMap.Demo
+{
+    public interface IDemoNaming
+    {
+        string GetFenceName(FenceTypeId id);
+        string GetObjectName(ObjectTypeId id);
+        string GetRoadName(RoadTypeId id);
+        string GetSurfaceName(BuildingTypeId id);
+        string GetSurfaceName(Type type);
+    }
+}

--- a/GameRealisticMap/ElevationModel/ElevationGrid.cs
+++ b/GameRealisticMap/ElevationModel/ElevationGrid.cs
@@ -154,5 +154,16 @@ namespace GameRealisticMap.ElevationModel
             }
             return (float)(total / count);
         }
+
+        public void Fill(float value)
+        {
+            for (var y = 0; y < size; ++y)
+            {
+                for (var x = 0; x < size; ++x)
+                {
+                    elevationGrid[y, x] = value;
+                }
+            }
+        }
     }
 }

--- a/GameRealisticMap/Geometries/BoxSideHelper.cs
+++ b/GameRealisticMap/Geometries/BoxSideHelper.cs
@@ -23,6 +23,12 @@ namespace GameRealisticMap.Geometries
                 return Enumerable.Empty<BoxSide>();
             }
 
+            return GetClosestList(box, paths, maxDistance, path, factor);
+        }
+
+        public static IEnumerable<BoxSide> GetClosestList<T>(BoundingBox box, IEnumerable<T> paths, float maxDistance, Func<T, TerrainPath> path, Func<T, float> factor)
+            where T : class, ITerrainEnvelope
+        {
             var sidesDistance = GetSidesPoints(box).Select(s => paths.Min(p => path(p).Distance(s) * factor(p))).ToList();
 
             return sides

--- a/GameRealisticMap/Geometries/TerrainPath.cs
+++ b/GameRealisticMap/Geometries/TerrainPath.cs
@@ -214,5 +214,24 @@ namespace GameRealisticMap.Geometries
             points[Points.Count - 1] = newEnd;
             return new TerrainPath(points);
         }
+
+        public static TerrainPath FromRectangle(TerrainPoint start, TerrainPoint end)
+        {
+            return new TerrainPath(
+                new List<TerrainPoint>()
+                {
+                    start,
+                    new TerrainPoint(end.X, start.Y),
+                    end,
+                    new TerrainPoint(start.X, end.Y),
+                    start
+                });
+        }
+
+        public static TerrainPath FromCircle(TerrainPoint origin, float radius)
+        {
+            return new TerrainPath(
+                GeometryHelper.SimpleCircle(origin.Vector, radius).Select(v => new TerrainPoint(v)).ToList());
+        }
     }
 }

--- a/GameRealisticMap/Geometries/TerrainPath.cs
+++ b/GameRealisticMap/Geometries/TerrainPath.cs
@@ -204,5 +204,15 @@ namespace GameRealisticMap.Geometries
             }
             return points;
         }
+
+        public TerrainPath ExtendBothEnds(float extendAtEachEnd)
+        {
+            var newStart = Points[0] + Vector2.Normalize(Points[0].Vector - Points[1].Vector) * extendAtEachEnd;
+            var newEnd = Points[Points.Count-1] + Vector2.Normalize(Points[Points.Count - 1].Vector - Points[Points.Count - 2].Vector) * extendAtEachEnd;
+            var points = Points.ToList();
+            points[0] = newStart;
+            points[Points.Count - 1] = newEnd;
+            return new TerrainPath(points);
+        }
     }
 }

--- a/GameRealisticMap/Osm/NoneOsmDataSource.cs
+++ b/GameRealisticMap/Osm/NoneOsmDataSource.cs
@@ -1,0 +1,25 @@
+﻿using GeoAPI.Geometries;
+using OsmSharp;
+using OsmSharp.Db;
+using OsmSharp.Db.Impl;
+
+namespace GameRealisticMap.Osm
+{
+    public sealed class NoneOsmDataSource : IOsmDataSource
+    {
+        public IEnumerable<OsmGeo> All => Enumerable.Empty<OsmGeo>();
+
+        public IEnumerable<Way> Ways => Enumerable.Empty<Way>();
+
+        public IEnumerable<Node> Nodes => Enumerable.Empty<Node>();
+
+        public IEnumerable<Relation> Relations => Enumerable.Empty<Relation>();
+
+        public SnapshotDb SnapshotDb { get; } = new SnapshotDb(new MemorySnapshotDb());
+
+        public IEnumerable<IGeometry> Interpret(OsmGeo osmGeo)
+        {
+            return Enumerable.Empty<IGeometry>();
+        }
+    }
+}

--- a/GameRealisticMap/Osm/OsmDataOverPassLoader.cs
+++ b/GameRealisticMap/Osm/OsmDataOverPassLoader.cs
@@ -77,6 +77,7 @@ out;"); ;
                 progress.WriteLine($"{query}");
                 using (var client = new HttpClient())
                 {
+                    client.Timeout = TimeSpan.FromSeconds(195);
                     using var download = await client.PostAsync(uri, new FormUrlEncodedContent(new Dictionary<string, string>() { { "data", query } }));
                     using var stream = await download.Content.ReadAsStreamAsync(); 
                     using (var target = File.Create(cacheFileName))

--- a/GameRealisticMap/Preview/PreviewRender.cs
+++ b/GameRealisticMap/Preview/PreviewRender.cs
@@ -83,6 +83,11 @@ namespace GameRealisticMap.Preview
         //    return new Position(p.Y, p.X);
         //}
 
+        public static async Task RenderHtml(BuildContext context, string targetFile)
+        {
+            await RenderHtml(new FeatureCollection(context.Catalog.GetOfType<IGeoJsonData>(context).SelectMany(b => b.ToGeoJson(p => p)).ToList()), targetFile);
+        }
+
         public static async Task RenderHtml(FeatureCollection collection, string targetFile)
         {
             using (var reader = new StreamReader(typeof(PreviewRender).Assembly.GetManifestResourceStream("GameRealisticMap.Preview.grm-preview.js")!))


### PR DESCRIPTION
Adds a demo world generation option for an asset configuration.

Adds also a side and front preview in composition editor

Includes fixes:
- Roads render order (primary roads are now above secondary roads)
- Bridge generation was incorrect (both due to generation itself and default configuration)
- Generation will no more failed when an area did not have any road or trail
- OSM Overpass timeout have been changed to match API maximum value (199 seconds)