### PR TITLE
Ocean support, and world wide support

### DIFF
--- a/GameRealisticMap.Arma3/Assets/TerrainMaterialUsage.cs
+++ b/GameRealisticMap.Arma3/Assets/TerrainMaterialUsage.cs
@@ -5,6 +5,8 @@
         Default,
         DefaultUrban,
         DefaultIndustrial,
+        Coastline,
+        OceanGround,
         ForestGround,
         Sand,
         Grass,

--- a/GameRealisticMap.Arma3/Builtin/CentralEurope.grma3a
+++ b/GameRealisticMap.Arma3/Builtin/CentralEurope.grma3a
@@ -3248,6 +3248,29 @@
       },
       {
         "Material": {
+          "NormalTexture": "z\\arm\\addons\\centraleurope\\data\\gdt\\arm_sand_centraleurope_nopx.paa",
+          "ColorTexture": "z\\arm\\addons\\centraleurope\\data\\gdt\\arm_sand_centraleurope_co.paa",
+          "Id": "F4A460FF",
+          "FakeSatPngImage": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAIVJREFUeJw1j0kOAzEIBJvF38w51zx/IpbQTMYWsiwVTeGf96urCix3x30E3b1/FxGwzGwhVZsSROQNTUFFMc9AunB3bUpEEGjIdPBW5SZ8rwt+DsAEVd3IytpIdpufNVEbB1IZhceFIyvzVj0ygMjK9T+eCbSvIddhBu1sbvFsQmFCmYIfOrZUavcGk1cAAAAASUVORK5CYII="
+        },
+        "Usages": [
+          "Coastline",
+          "Sand"
+        ]
+      },
+      {
+        "Material": {
+          "NormalTexture": "a3\\map_data\\gdt_seabed_nopx.paa",
+          "ColorTexture": "a3\\map_data\\gdt_seabed_co.paa",
+          "Id": "0026FFFF",
+          "FakeSatPngImage": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAMlJREFUeJwdjt1Og0AYRM/Cx58CLdVgou/iQ+j73xlqTCBtpbjdLrt+7d1czJk58vH5HrvHHcP4RVtviTHSVDXjcWKaR6QuK34Oe/7cL2aJ5FmBMS1912PdjGTyQJE7iIaiKLk4y7wcsVdHVdZILhlpKrRNR4gBv1pC8Cx2Ytv0yDAN91/nHQa4AS/dmw6mJEaQyEqSaEghrKsKbtTpWz0ih/MJ8VevVIokhVI3yZrARa+8Lp5VMhMtCKdl5Gnzei/P1iF6tWuf+QcZ7VctNm5rngAAAABJRU5ErkJggg=="
+        },
+        "Usages": [
+          "OceanGround"
+        ]
+      },
+      {
+        "Material": {
           "NormalTexture": "z\\arm\\addons\\centraleurope\\data\\gdt\\arm_forest_centraleurope_nopx.paa",
           "ColorTexture": "z\\arm\\addons\\centraleurope\\data\\gdt\\arm_forest_centraleurope_co.paa",
           "Id": "008000FF",
@@ -3255,17 +3278,6 @@
         },
         "Usages": [
           "ForestGround"
-        ]
-      },
-      {
-        "Material": {
-          "NormalTexture": "z\\arm\\addons\\centraleurope\\data\\gdt\\arm_sand_centraleurope_nopx.paa",
-          "ColorTexture": "z\\arm\\addons\\centraleurope\\data\\gdt\\arm_sand_centraleurope_co.paa",
-          "Id": "F4A460FF",
-          "FakeSatPngImage": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAIVJREFUeJw1j0kOAzEIBJvF38w51zx/IpbQTMYWsiwVTeGf96urCix3x30E3b1/FxGwzGwhVZsSROQNTUFFMc9AunB3bUpEEGjIdPBW5SZ8rwt+DsAEVd3IytpIdpufNVEbB1IZhceFIyvzVj0ygMjK9T+eCbSvIddhBu1sbvFsQmFCmYIfOrZUavcGk1cAAAAASUVORK5CYII="
-        },
-        "Usages": [
-          "Sand"
         ]
       },
       {
@@ -3824,6 +3836,7 @@
           }
         ],
         "Ends": [],
+        "Objects": [],
         "Label": "",
         "UseAnySize": false
       }
@@ -3860,6 +3873,7 @@
         "LeftCorners": [],
         "RightCorners": [],
         "Ends": [],
+        "Objects": [],
         "Label": "",
         "UseAnySize": false
       }
@@ -3896,6 +3910,7 @@
         "LeftCorners": [],
         "RightCorners": [],
         "Ends": [],
+        "Objects": [],
         "Label": "",
         "UseAnySize": false
       }

--- a/GameRealisticMap.Arma3/Builtin/Sahel.grma3a
+++ b/GameRealisticMap.Arma3/Builtin/Sahel.grma3a
@@ -2738,6 +2738,29 @@
       },
       {
         "Material": {
+          "NormalTexture": "z\\arm\\addons\\sahel\\data\\gdt\\arm_sand_sahel_nopx.paa",
+          "ColorTexture": "z\\arm\\addons\\sahel\\data\\gdt\\arm_sand_sahel_co.paa",
+          "Id": "F4A460FF",
+          "FakeSatPngImage": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVR4nGOpSHX/z4AHsDAQAMNDAQBBuwJEQhYxTgAAAABJRU5ErkJggg=="
+        },
+        "Usages": [
+          "Coastline",
+          "Sand"
+        ]
+      },
+      {
+        "Material": {
+          "NormalTexture": "a3\\map_data\\gdt_seabed_nopx.paa",
+          "ColorTexture": "a3\\map_data\\gdt_seabed_co.paa",
+          "Id": "0026FFFF",
+          "FakeSatPngImage": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAMlJREFUeJwdjt1Og0AYRM/Cx58CLdVgou/iQ+j73xlqTCBtpbjdLrt+7d1czJk58vH5HrvHHcP4RVtviTHSVDXjcWKaR6QuK34Oe/7cL2aJ5FmBMS1912PdjGTyQJE7iIaiKLk4y7wcsVdHVdZILhlpKrRNR4gBv1pC8Cx2Ytv0yDAN91/nHQa4AS/dmw6mJEaQyEqSaEghrKsKbtTpWz0ih/MJ8VevVIokhVI3yZrARa+8Lp5VMhMtCKdl5Gnzei/P1iF6tWuf+QcZ7VctNm5rngAAAABJRU5ErkJggg=="
+        },
+        "Usages": [
+          "OceanGround"
+        ]
+      },
+      {
+        "Material": {
           "NormalTexture": "z\\arm\\addons\\sahel\\data\\gdt\\arm_forest_sahel_nopx.paa",
           "ColorTexture": "z\\arm\\addons\\sahel\\data\\gdt\\arm_forest_sahel_co.paa",
           "Id": "008000FF",
@@ -2745,17 +2768,6 @@
         },
         "Usages": [
           "ForestGround"
-        ]
-      },
-      {
-        "Material": {
-          "NormalTexture": "z\\arm\\addons\\sahel\\data\\gdt\\arm_sand_sahel_nopx.paa",
-          "ColorTexture": "z\\arm\\addons\\sahel\\data\\gdt\\arm_sand_sahel_co.paa",
-          "Id": "F4A460FF",
-          "FakeSatPngImage": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVR4nGOpSHX/z4AHsDAQAMNDAQBBuwJEQhYxTgAAAABJRU5ErkJggg=="
-        },
-        "Usages": [
-          "Sand"
         ]
       },
       {
@@ -3304,6 +3316,7 @@
         "Probability": 1,
         "Straights": [
           {
+            "Proportion": 1,
             "Model": {
               "Objects": [
                 {
@@ -3315,6 +3328,7 @@
             "Size": 5
           },
           {
+            "Proportion": 1,
             "Model": {
               "Objects": [
                 {
@@ -3326,7 +3340,12 @@
             "Size": 2.5
           }
         ],
-        "Label": ""
+        "LeftCorners": [],
+        "RightCorners": [],
+        "Ends": [],
+        "Objects": [],
+        "Label": "",
+        "UseAnySize": false
       }
     ],
     "Fence": [
@@ -3334,6 +3353,7 @@
         "Probability": 0.5,
         "Straights": [
           {
+            "Proportion": 1,
             "Model": {
               "Objects": [
                 {
@@ -3345,12 +3365,18 @@
             "Size": 6.5
           }
         ],
-        "Label": ""
+        "LeftCorners": [],
+        "RightCorners": [],
+        "Ends": [],
+        "Objects": [],
+        "Label": "",
+        "UseAnySize": false
       },
       {
         "Probability": 0.5,
         "Straights": [
           {
+            "Proportion": 1,
             "Model": {
               "Objects": [
                 {
@@ -3362,6 +3388,7 @@
             "Size": 9
           },
           {
+            "Proportion": 1,
             "Model": {
               "Objects": [
                 {
@@ -3373,9 +3400,18 @@
             "Size": 9
           }
         ],
-        "Label": ""
+        "LeftCorners": [],
+        "RightCorners": [],
+        "Ends": [],
+        "Objects": [],
+        "Label": "",
+        "UseAnySize": false
       }
     ]
+  },
+  "Railways": {
+    "Straights": [],
+    "Crossings": []
   },
   "BaseWorldName": "arm_world_sahel",
   "BaseDependency": "arm_sahel",

--- a/GameRealisticMap.Arma3/GameEngine/GameConfigGenerator.cs
+++ b/GameRealisticMap.Arma3/GameEngine/GameConfigGenerator.cs
@@ -2,6 +2,7 @@
 using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.IO;
 using GameRealisticMap.ManMade.Places;
+using GameRealisticMap.Nature.Ocean;
 
 namespace GameRealisticMap.Arma3.GameEngine
 {
@@ -27,17 +28,18 @@ namespace GameRealisticMap.Arma3.GameEngine
                 gameFileSystemWriter.WriteTextFile(configCpp, GenerateConfigCpp(config, context.GetData<CitiesData>()));
             }
 
-            gameFileSystemWriter.WriteTextFile($"{config.PboPrefix}\\mapinfos.hpp", GenerateMapInfos(config, area));
+            gameFileSystemWriter.WriteTextFile($"{config.PboPrefix}\\mapinfos.hpp", GenerateMapInfos(config, area, context.GetData<OceanData>().IsIsland));
 
             gameFileSystemWriter.WriteTextFile($"{config.PboPrefix}\\names.hpp", GenerateNames(context.GetData<CitiesData>()));
         }
 
-        private string GenerateMapInfos(IArma3MapConfig config, ITerrainArea area)
+
+        private string GenerateMapInfos(IArma3MapConfig config, ITerrainArea area, bool isIsland)
         {
             var center = area.TerrainPointToLatLng(new Geometries.TerrainPoint(config.SizeInMeters / 2, config.SizeInMeters / 2));
             var southWest = area.TerrainPointToLatLng(new Geometries.TerrainPoint(0, 0));
             var northEast = area.TerrainPointToLatLng(new Geometries.TerrainPoint(config.SizeInMeters, config.SizeInMeters));
-            var material = assets.Materials.GetMaterialByUsage(TerrainMaterialUsage.Default);
+            var material = assets.Materials.GetMaterialByUsage(isIsland ? TerrainMaterialUsage.OceanGround : TerrainMaterialUsage.Default);
 
             var centerUTM = new CoordinateSharp.Coordinate(center.Y, center.X).UTM;
 

--- a/GameRealisticMap.Arma3/Imagery/FakeSatRender.cs
+++ b/GameRealisticMap.Arma3/Imagery/FakeSatRender.cs
@@ -2,6 +2,7 @@
 using GameRealisticMap.Arma3.Assets;
 using GameRealisticMap.Arma3.IO;
 using GameRealisticMap.Geometries;
+using GameRealisticMap.Nature.Ocean;
 using GameRealisticMap.Reporting;
 using HugeImages;
 using HugeImages.Processing;
@@ -33,10 +34,11 @@ namespace GameRealisticMap.Arma3.Imagery
 
         public Image<Rgba32> RenderSatOut(IArma3MapConfig config, IContext context, int size)
         {
+            var isIsland = context.GetData<OceanData>().IsIsland;
             var image = new Image<Rgba32>(size, size);
             image.Mutate(d =>
             {
-                d.Fill(GetBrush(materialLibrary.GetMaterialByUsage(TerrainMaterialUsage.Default)));
+                d.Fill(GetBrush(materialLibrary.GetMaterialByUsage(isIsland ? TerrainMaterialUsage.OceanGround : TerrainMaterialUsage.Default)));
                 d.GaussianBlur(1.5f);
             });
             return image;

--- a/GameRealisticMap.Arma3/Imagery/IdMapRenderBase.cs
+++ b/GameRealisticMap.Arma3/Imagery/IdMapRenderBase.cs
@@ -5,6 +5,7 @@ using GameRealisticMap.ManMade;
 using GameRealisticMap.ManMade.Buildings;
 using GameRealisticMap.ManMade.Farmlands;
 using GameRealisticMap.Nature.Forests;
+using GameRealisticMap.Nature.Ocean;
 using GameRealisticMap.Nature.RockAreas;
 using GameRealisticMap.Nature.Surfaces;
 using GameRealisticMap.Nature.Watercourses;
@@ -49,6 +50,10 @@ namespace GameRealisticMap.Arma3.Imagery
 
                 DrawPolygons(config, d, TerrainMaterialUsage.DefaultIndustrial,
                     categories.Areas.Where(c => c.BuildingType == BuildingTypeId.Industrial).SelectMany(c => c.PolyList));
+
+                DrawPolygons(config, d, TerrainMaterialUsage.OceanGround, context.GetData<OceanData>().Polygons);
+
+                DrawPolygonsWithCrown(config, d, TerrainMaterialUsage.Coastline, 2.5f, context.GetData<CoastlineData>().Polygons);
 
                 DrawPolygonsWithCrown(config, d, TerrainMaterialUsage.ForestGround, 2.5f, context.GetData<ForestData>().Polygons);
 

--- a/GameRealisticMap.CommandLine/Program.cs
+++ b/GameRealisticMap.CommandLine/Program.cs
@@ -20,15 +20,15 @@ namespace GameRealisticMap.CommandLine
 
             var area = TerrainAreaUTM.CreateFromCenter("43.805011792296725, -1.4100638139572768", 3.25f, 256);
             var render = new PreviewRender(area, new ImageryOptions());
-            await render.RenderHtml<OceanData>(progress, Path.GetFullPath("preview2.html"));
+            await render.RenderHtml(progress, Path.GetFullPath("preview2.html"));
 
             area = TerrainAreaUTM.CreateFromCenter("46.71532290005527, -2.3412981298116162", 4.5f, 2048);
             render = new PreviewRender(area, new ImageryOptions());
-            await render.RenderHtml<OceanData>(progress, Path.GetFullPath("preview.html"));
+            await render.RenderHtml(progress, Path.GetFullPath("preview.html"));
 
             area = TerrainAreaUTM.CreateFromSouthWest("47.6856, 6.8270", 2.5f, 1024);
             render = new PreviewRender(area, new ImageryOptions());
-            await render.RenderHtml(progress, Path.GetFullPath("preview3.html"), true);
+            await render.RenderHtml(progress, Path.GetFullPath("preview3.html"));
         }
 
     }

--- a/GameRealisticMap.CommandLine/Program.cs
+++ b/GameRealisticMap.CommandLine/Program.cs
@@ -8,6 +8,7 @@ using PdfSharpCore.Pdf.Filters;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp;
 using MapToolkit.DataCells;
+using GameRealisticMap.Nature.Ocean;
 
 namespace GameRealisticMap.CommandLine
 {
@@ -17,23 +18,17 @@ namespace GameRealisticMap.CommandLine
         {
             var progress = new ConsoleProgressSystem();
 
-            var area = TerrainAreaUTM.CreateFromSouthWest("47.6856, 6.8270", 2.5f, 1024/*8*/);
-
+            var area = TerrainAreaUTM.CreateFromCenter("43.805011792296725, -1.4100638139572768", 3.25f, 256);
             var render = new PreviewRender(area, new ImageryOptions());
+            await render.RenderHtml<OceanData>(progress, Path.GetFullPath("preview2.html"));
 
-            await render.RenderHtml(progress, Path.GetFullPath("preview.html"), true);
+            area = TerrainAreaUTM.CreateFromCenter("46.71532290005527, -2.3412981298116162", 4.5f, 2048);
+            render = new PreviewRender(area, new ImageryOptions());
+            await render.RenderHtml<OceanData>(progress, Path.GetFullPath("preview.html"));
 
-            //var x = JsonSerializer.Serialize(ImageTiler.DefaultToWebp(context.GetData<RawSatelliteImageData>().Image, "rawsat"));
-
-            // new HillshaderFast(new MapToolkit.Vector(2.5, 2.5)).GetPixelsAlphaBelowFlat(context.GetData<ElevationData>().Elevation.ToDataCell()).SaveAsPng("elevation.png");
-
-            //var catalog = new BuildersCatalog(progress, new DefaultRoadTypeLibrary(), true);
-            //var loader = new OsmDataOverPassLoader(progress);
-            //var osmSource = await loader.Load(area);
-            //var context = new BuildContext(catalog, progress, area, osmSource, new ImageryOptions());
-            //var elevation = context.GetData<ElevationData>();
-
-            //elevation.Elevation.ToDataCell().SaveImagePreview(Path.GetFullPath("preview.png"));
+            area = TerrainAreaUTM.CreateFromSouthWest("47.6856, 6.8270", 2.5f, 1024);
+            render = new PreviewRender(area, new ImageryOptions());
+            await render.RenderHtml(progress, Path.GetFullPath("preview3.html"), true);
         }
 
     }

--- a/GameRealisticMap.Studio/Labels.Designer.cs
+++ b/GameRealisticMap.Studio/Labels.Designer.cs
@@ -268,6 +268,15 @@ namespace GameRealisticMap.Studio {
         }
         
         /// <summary>
+        ///   Recherche une chaîne localisée semblable à Default ground - Coastline.
+        /// </summary>
+        public static string AssetCoastline {
+            get {
+                return ResourceManager.GetString("AssetCoastline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Recherche une chaîne localisée semblable à Commercial Building.
         /// </summary>
         public static string AssetCommercial {
@@ -525,6 +534,15 @@ namespace GameRealisticMap.Studio {
         public static string AssetObjects {
             get {
                 return ResourceManager.GetString("AssetObjects", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Ocean ground.
+        /// </summary>
+        public static string AssetOceanGround {
+            get {
+                return ResourceManager.GetString("AssetOceanGround", resourceCulture);
             }
         }
         
@@ -993,6 +1011,15 @@ namespace GameRealisticMap.Studio {
         public static string Close {
             get {
                 return ResourceManager.GetString("Close", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Recherche une chaîne localisée semblable à Default ground coast line.
+        /// </summary>
+        public static string CoastLine {
+            get {
+                return ResourceManager.GetString("CoastLine", resourceCulture);
             }
         }
         

--- a/GameRealisticMap.Studio/Labels.Designer.cs
+++ b/GameRealisticMap.Studio/Labels.Designer.cs
@@ -1015,15 +1015,6 @@ namespace GameRealisticMap.Studio {
         }
         
         /// <summary>
-        ///   Recherche une chaîne localisée semblable à Default ground coast line.
-        /// </summary>
-        public static string CoastLine {
-            get {
-                return ResourceManager.GetString("CoastLine", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Recherche une chaîne localisée semblable à Color Id.
         /// </summary>
         public static string ColorId {

--- a/GameRealisticMap.Studio/Labels.fr.resx
+++ b/GameRealisticMap.Studio/Labels.fr.resx
@@ -957,4 +957,10 @@ Vous pouvez éventuellement activer d'autres mods.</value>
   <data name="ViewImportInstructions" xml:space="preserve">
     <value>Voir les instructions d'import (Anglais uniquement)</value>
   </data>
+  <data name="AssetOceanGround" xml:space="preserve">
+    <value>Fond de l'océan</value>
+  </data>
+  <data name="AssetCoastline" xml:space="preserve">
+    <value>Par défaut - Littoral</value>
+  </data>
 </root>

--- a/GameRealisticMap.Studio/Labels.resx
+++ b/GameRealisticMap.Studio/Labels.resx
@@ -957,4 +957,13 @@ You may eventually enable other mods.</value>
   <data name="ViewImportInstructions" xml:space="preserve">
     <value>View import instructions</value>
   </data>
+  <data name="AssetOceanGround" xml:space="preserve">
+    <value>Ocean ground</value>
+  </data>
+  <data name="CoastLine" xml:space="preserve">
+    <value>Default ground coast line</value>
+  </data>
+  <data name="AssetCoastline" xml:space="preserve">
+    <value>Default ground - Coastline</value>
+  </data>
 </root>

--- a/GameRealisticMap.Studio/Labels.resx
+++ b/GameRealisticMap.Studio/Labels.resx
@@ -960,9 +960,6 @@ You may eventually enable other mods.</value>
   <data name="AssetOceanGround" xml:space="preserve">
     <value>Ocean ground</value>
   </data>
-  <data name="CoastLine" xml:space="preserve">
-    <value>Default ground coast line</value>
-  </data>
   <data name="AssetCoastline" xml:space="preserve">
     <value>Default ground - Coastline</value>
   </data>

--- a/GameRealisticMap/BuildersCatalog.cs
+++ b/GameRealisticMap/BuildersCatalog.cs
@@ -28,6 +28,7 @@ namespace GameRealisticMap
         public BuildersCatalog(IProgressSystem progress, IRoadTypeLibrary<IRoadTypeInfos> library, IRailwayCrossingResolver? crossingResolver = null, bool useFullGeoJson = false)
         {
             Register(new OceanBuilder(progress));
+            Register(new CoastlineBuilder(progress));
             Register(new RawSatelliteImageBuilder(progress));
             Register(new RawElevationBuilder(progress));
             Register(new CategoryAreaBuilder(progress));

--- a/GameRealisticMap/BuildersCatalog.cs
+++ b/GameRealisticMap/BuildersCatalog.cs
@@ -10,6 +10,7 @@ using GameRealisticMap.ManMade.Roads;
 using GameRealisticMap.ManMade.Roads.Libraries;
 using GameRealisticMap.Nature.Forests;
 using GameRealisticMap.Nature.Lakes;
+using GameRealisticMap.Nature.Ocean;
 using GameRealisticMap.Nature.RockAreas;
 using GameRealisticMap.Nature.Scrubs;
 using GameRealisticMap.Nature.Surfaces;
@@ -26,6 +27,7 @@ namespace GameRealisticMap
 
         public BuildersCatalog(IProgressSystem progress, IRoadTypeLibrary<IRoadTypeInfos> library, IRailwayCrossingResolver? crossingResolver = null, bool useFullGeoJson = false)
         {
+            Register(new OceanBuilder(progress));
             Register(new RawSatelliteImageBuilder(progress));
             Register(new RawElevationBuilder(progress));
             Register(new CategoryAreaBuilder(progress));

--- a/GameRealisticMap/ElevationModel/ElevationBuilder.cs
+++ b/GameRealisticMap/ElevationModel/ElevationBuilder.cs
@@ -47,7 +47,7 @@ namespace GameRealisticMap.ElevationModel
                 var contour = new ContourGraph();
                 using (var report = progress.CreateStepPercent("Contours"))
                 {
-                    contour.Add(constraintGrid.Grid.ToDataCell(), new ContourLevelGenerator(1, 1), false, report);
+                    contour.Add(constraintGrid.Grid.ToDataCell(), new ContourLevelGenerator(-50, 5), false, report);
                 }
                 return new ElevationData(constraintGrid.Grid, contour.Lines.Select(l => new TerrainPath(l.Points.Select(p => new TerrainPoint((float)p.Longitude, (float)p.Latitude)).ToList())));
             }

--- a/GameRealisticMap/ElevationModel/RawElevationBuilder.cs
+++ b/GameRealisticMap/ElevationModel/RawElevationBuilder.cs
@@ -93,14 +93,14 @@ namespace GameRealisticMap.ElevationModel
             {
                 // Alternative Elevation of surface, but requires JAXA credits
                 var aw3d30 = new DemDatabase(new DemHttpStorage(new Uri("https://dem.pmad.net/AW3D30/")));
-                if (!srtm.HasFullData(start, end).GetAwaiter().GetResult())
+                if (!aw3d30.HasFullData(start, end).GetAwaiter().GetResult())
                 {
                     view = viewFull;
                 }
                 else
                 {
                     dbCredits.Add("AW3D30");
-                    view = aw3d30.CreateView<ushort>(start, end).GetAwaiter().GetResult().ToDataCell(); // TODO: check AW3D30 internal format
+                    view = aw3d30.CreateView<short>(start, end).GetAwaiter().GetResult().ToDataCell(); // TODO: check AW3D30 internal format
                 }
             }
             else

--- a/GameRealisticMap/ElevationModel/RawElevationData.cs
+++ b/GameRealisticMap/ElevationModel/RawElevationData.cs
@@ -7,8 +7,16 @@ namespace GameRealisticMap.ElevationModel
         public RawElevationData(ElevationGrid rawElevation)
         {
             RawElevation = rawElevation;
+            Credits = new ();
+        }
+
+        public RawElevationData(ElevationGrid rawElevation, List<string> credits)
+        {
+            RawElevation = rawElevation;
+            Credits = credits;
         }
 
         public ElevationGrid RawElevation { get; }
+        public List<string> Credits { get; }
     }
 }

--- a/GameRealisticMap/ElevationModel/RawElevationSource.cs
+++ b/GameRealisticMap/ElevationModel/RawElevationSource.cs
@@ -1,0 +1,19 @@
+﻿using MapToolkit.DataCells;
+
+namespace GameRealisticMap.ElevationModel
+{
+    internal class RawElevationSource
+    {
+        
+        public RawElevationSource(List<string> dbCredits, IDemDataCell view, IDemDataCell viewFull)
+        {
+            this.Credits = dbCredits;
+            this.SurfaceOnly = view;
+            this.Ground = viewFull;
+        }
+
+        public List<string> Credits { get; }
+        public IDemDataCell SurfaceOnly { get; }
+        public IDemDataCell Ground { get; }
+    }
+}

--- a/GameRealisticMap/ElevationModel/RawElevationSource.cs
+++ b/GameRealisticMap/ElevationModel/RawElevationSource.cs
@@ -1,4 +1,6 @@
-﻿using MapToolkit.DataCells;
+﻿using GeoAPI.Geometries;
+using MapToolkit;
+using MapToolkit.DataCells;
 
 namespace GameRealisticMap.ElevationModel
 {
@@ -15,5 +17,44 @@ namespace GameRealisticMap.ElevationModel
         public List<string> Credits { get; }
         public IDemDataCell SurfaceOnly { get; }
         public IDemDataCell Ground { get; }
+
+        internal float GetElevation(Coordinate latLong, byte oceanMaskValue)
+        {
+            if (oceanMaskValue == 0)
+            {
+                return (float)GetSurfaceElevation(latLong);
+            }
+            if ( oceanMaskValue == 255)
+            {
+                return (float)GetOceanDepth(latLong);
+            }
+            var factor = oceanMaskValue / 255.0;
+            return (float)((GetOceanDepth(latLong) * factor) + (GetSurfaceElevation(latLong) * (1 - factor)));
+        }
+
+        private double GetOceanDepth(Coordinate latLong)
+        {
+            var elevation = GetElevationBilinear(Ground, latLong.Y, latLong.X);
+            if (elevation > 0)
+            {
+                return -1;
+            }
+            return elevation;
+        }
+
+        private double GetSurfaceElevation(Coordinate latLong)
+        {
+            var elevation = GetElevationBilinear(SurfaceOnly, latLong.Y, latLong.X);
+            if (double.IsNaN(elevation) || elevation < 0.5f)
+            {
+                elevation = 0.5f;
+            }
+            return elevation;
+        }
+
+        private double GetElevationBilinear(IDemDataCell view, double lat, double lon)
+        {
+            return view.GetLocalElevation(new Coordinates(lat, lon), DefaultInterpolation.Instance);
+        }
     }
 }

--- a/GameRealisticMap/Geometries/TerrainPath.cs
+++ b/GameRealisticMap/Geometries/TerrainPath.cs
@@ -281,5 +281,6 @@ namespace GameRealisticMap.Geometries
         public bool IsClosed => FirstPoint.Equals(LastPoint);
 
         public bool IsCounterClockWise => Points.IsCounterClockWise();
+        public bool IsClockWise => !Points.IsCounterClockWise();
     }
 }

--- a/GameRealisticMap/Geometries/TerrainPolygon.cs
+++ b/GameRealisticMap/Geometries/TerrainPolygon.cs
@@ -282,7 +282,7 @@ namespace GameRealisticMap.Geometries
             return result;
         }
 
-        private IEnumerable<TerrainPolygon> Substract(TerrainPolygon other)
+        public IEnumerable<TerrainPolygon> Substract(TerrainPolygon other)
         {
             var clipper = new Clipper();
             clipper.AddPath(Shell.Select(c => c.ToIntPoint()).ToList(), PolyType.ptSubject, true);

--- a/GameRealisticMap/Nature/BasicRadialBuilder.cs
+++ b/GameRealisticMap/Nature/BasicRadialBuilder.cs
@@ -6,6 +6,7 @@ using GameRealisticMap.ManMade.Farmlands;
 using GameRealisticMap.ManMade.Railways;
 using GameRealisticMap.ManMade.Roads;
 using GameRealisticMap.Nature.Forests;
+using GameRealisticMap.Nature.Ocean;
 using GameRealisticMap.Nature.RockAreas;
 using GameRealisticMap.Nature.Scrubs;
 using GameRealisticMap.Nature.Surfaces;
@@ -38,7 +39,8 @@ namespace GameRealisticMap.Nature
                 .Concat(context.GetData<RocksData>().Polygons)
                 .Concat(context.GetData<MeadowsData>().Polygons)
                 .Concat(context.GetData<FarmlandsData>().Polygons)
-                .Concat(context.GetData<CategoryAreaData>().Areas.SelectMany(a => a.PolyList));
+                .Concat(context.GetData<CategoryAreaData>().Areas.SelectMany(a => a.PolyList))
+                .Concat(context.GetData<OceanData>().Polygons);
         }
 
         public TEdge Build(IBuildContext context)

--- a/GameRealisticMap/Nature/Ocean/CoastlineBuilder.cs
+++ b/GameRealisticMap/Nature/Ocean/CoastlineBuilder.cs
@@ -1,0 +1,32 @@
+﻿using GameRealisticMap.Geometries;
+using GameRealisticMap.Reporting;
+
+namespace GameRealisticMap.Nature.Ocean
+{
+    internal class CoastlineBuilder : IDataBuilder<CoastlineData>
+    {
+        private readonly IProgressSystem progress;
+
+        public CoastlineBuilder(IProgressSystem progress)
+        {
+            this.progress = progress;
+        }
+
+        public CoastlineData Build(IBuildContext context)
+        {
+            var coastlines = context.OsmSource.Ways
+                .Where(w => w.Tags != null && w.Tags.GetValue("natural") == "coastline")
+                .SelectMany(w => context.OsmSource.Interpret(w))
+                .SelectMany(w => TerrainPath.FromGeometry(w, context.Area.LatLngToTerrainPoint))
+                .Where(p => p.EnveloppeIntersects(context.Area.TerrainBounds))
+                .SelectMany(p => p.ClippedBy(context.Area.TerrainBounds))
+                .SelectMany(p => TerrainPolygon.FromPath(p.Points, CoastlineData.Width))
+                .SelectMany(p => p.ClippedBy(context.Area.TerrainBounds))
+                .ToList();
+
+            using var report = progress.CreateStep("Merge", coastlines.Count);
+            var result = TerrainPolygon.MergeAll(coastlines, report);
+            return new CoastlineData(result);
+        }
+    }
+}

--- a/GameRealisticMap/Nature/Ocean/CoastlineData.cs
+++ b/GameRealisticMap/Nature/Ocean/CoastlineData.cs
@@ -6,7 +6,7 @@ namespace GameRealisticMap.Nature.Ocean
 {
     public class CoastlineData : IBasicTerrainData
     {
-        public const float Width = 4f;
+        public const float Width = 10f;
 
         public CoastlineData(List<TerrainPolygon> polygons)
         {

--- a/GameRealisticMap/Nature/Ocean/CoastlineData.cs
+++ b/GameRealisticMap/Nature/Ocean/CoastlineData.cs
@@ -1,0 +1,25 @@
+﻿using GameRealisticMap.Geometries;
+using GeoJSON.Text.Feature;
+using GeoJSON.Text.Geometry;
+
+namespace GameRealisticMap.Nature.Ocean
+{
+    public class CoastlineData : IBasicTerrainData
+    {
+        public const float Width = 4f;
+
+        public CoastlineData(List<TerrainPolygon> polygons)
+        {
+            Polygons = polygons;
+        }
+        public List<TerrainPolygon> Polygons { get; }
+
+        public IEnumerable<Feature> ToGeoJson(Func<TerrainPoint, IPosition> project)
+        {
+            var properties = new Dictionary<string, object>() {
+                {"type", "coastline" }
+            };
+            return Polygons.Select(b => new Feature(b.ToGeoJson(project), properties));
+        }
+    }
+}

--- a/GameRealisticMap/Nature/Ocean/OceanBuilder.cs
+++ b/GameRealisticMap/Nature/Ocean/OceanBuilder.cs
@@ -25,7 +25,7 @@ namespace GameRealisticMap.Nature.Ocean
             if ( coastlines.Count == 0)
             {
                 // No coastlines, assume land-only
-                return new OceanData(new List<TerrainPolygon>(0));
+                return new OceanData(new List<TerrainPolygon>(0), new List<TerrainPolygon>(1) { context.Area.TerrainBounds });
             }
 
             CompleteCounterClockWiseOnEdges(coastlines, context.Area.TerrainBounds);
@@ -40,9 +40,11 @@ namespace GameRealisticMap.Nature.Ocean
             var oceanBaseLine = context.Area.TerrainBounds.
                 SubstractAll(mergedCoastlines.Where(r => r.IsCounterClockWise).Select(l => new TerrainPolygon(l.Points)));
 
-            var polygons = TerrainPolygon.MergeAll(oceanBaseLine.Concat(mergedCoastlines.Where(r => r.IsClockWise).Select(l => new TerrainPolygon(l.Points))).ToList());
+            var oceanPolygons = TerrainPolygon.MergeAll(oceanBaseLine.Concat(mergedCoastlines.Where(r => r.IsClockWise).Select(l => new TerrainPolygon(l.Points))).ToList());
 
-            return new OceanData(polygons);
+            var landPolygons = context.Area.TerrainBounds.SubstractAll(oceanPolygons).ToList();
+
+            return new OceanData(oceanPolygons, landPolygons);
         }
         
         private static void CompleteCounterClockWiseOnEdges(IEnumerable<TerrainPath> paths, ITerrainEnvelope envelope)

--- a/GameRealisticMap/Nature/Ocean/OceanBuilder.cs
+++ b/GameRealisticMap/Nature/Ocean/OceanBuilder.cs
@@ -25,7 +25,7 @@ namespace GameRealisticMap.Nature.Ocean
             if ( coastlines.Count == 0)
             {
                 // No coastlines, assume land-only
-                return new OceanData(new List<TerrainPolygon>(0), new List<TerrainPolygon>(1) { context.Area.TerrainBounds });
+                return new OceanData(new List<TerrainPolygon>(0), new List<TerrainPolygon>(1) { context.Area.TerrainBounds }, false);
             }
 
             CompleteCounterClockWiseOnEdges(coastlines, context.Area.TerrainBounds);
@@ -44,9 +44,22 @@ namespace GameRealisticMap.Nature.Ocean
 
             var landPolygons = context.Area.TerrainBounds.SubstractAll(oceanPolygons).ToList();
 
-            return new OceanData(oceanPolygons, landPolygons);
+            return new OceanData(oceanPolygons, landPolygons, IsIsland(oceanPolygons, context.Area));
         }
-        
+
+        private bool IsIsland(List<TerrainPolygon> oceanPolygons, ITerrainArea area)
+        {
+            if (oceanPolygons.Count == 1)
+            {
+                var outer = oceanPolygons[0].Shell;
+                if (outer.Count == 5)
+                {
+                    return new TerrainPolygon(outer).Area == area.TerrainBounds.Area;
+                }
+            }
+            return false;
+        }
+
         private static void CompleteCounterClockWiseOnEdges(IEnumerable<TerrainPath> paths, ITerrainEnvelope envelope)
         {
             CompleteCounterClockWiseOnEdges(paths, envelope.MinPoint, envelope.MaxPoint);

--- a/GameRealisticMap/Nature/Ocean/OceanBuilder.cs
+++ b/GameRealisticMap/Nature/Ocean/OceanBuilder.cs
@@ -1,0 +1,197 @@
+﻿using GameRealisticMap.Geometries;
+using GameRealisticMap.Reporting;
+
+namespace GameRealisticMap.Nature.Ocean
+{
+    internal class OceanBuilder : IDataBuilder<OceanData>
+    {
+        private readonly IProgressSystem progress;
+
+        public OceanBuilder(IProgressSystem progress)
+        {
+            this.progress = progress;
+        }
+
+        public OceanData Build(IBuildContext context)
+        {
+            var x = context.OsmSource.Ways.FirstOrDefault(w => w.Id == 149847784);
+
+            var lines = context.OsmSource.Ways
+                .Where(w => w.Tags != null && w.Tags.GetValue("natural") == "coastline")
+                .SelectMany(w => context.OsmSource.Interpret(w))
+                .SelectMany(w => TerrainPath.FromGeometry(w, context.Area.LatLngToTerrainPoint))
+                .Where(p => p.EnveloppeIntersects(context.Area.TerrainBounds))
+                .SelectMany(p => p.ClippedKeepOrientation(context.Area.TerrainBounds))
+                .ToList();
+
+            if ( lines.Count == 0)
+            {
+                return new OceanData(new List<TerrainPolygon>(0));
+            }
+
+            CompletePathOnEdges(lines, context.Area.TerrainBounds);
+
+            var result = MergeOriented(lines).Where(r => r.IsClosed).ToList();
+
+            // CounterClockWise => Lands
+            // ClockWise => Ocean
+
+            var ocean = result.Where(r => !r.IsCounterClockWise).ToList();
+
+            var oceanBaseLine = context.Area.TerrainBounds.
+                SubstractAll(result.Where(r => r.IsCounterClockWise).Select(l => new TerrainPolygon(l.Points)));
+
+            var polygons = TerrainPolygon.MergeAll(oceanBaseLine.Concat(result.Where(r => !r.IsCounterClockWise).Select(l => new TerrainPolygon(l.Points))).ToList());
+
+            return new OceanData(polygons);
+        }
+        
+        private static void CompletePathOnEdges(IEnumerable<TerrainPath> paths, ITerrainEnvelope envelope)
+        {
+            CompletePathOnEdges(paths, envelope.MinPoint, envelope.MaxPoint);
+        }
+
+        private static void CompletePathOnEdges(IEnumerable<TerrainPath> paths, TerrainPoint edgeSW, TerrainPoint edgeNE)
+        {            
+            foreach (var line in paths)
+            {
+                if (!line.IsClosed)
+                {
+                    if (line.FirstPoint.Y == edgeNE.Y) // First On North, look EAST
+                    {
+                        LookEast(edgeSW, edgeNE, paths, line, line.FirstPoint);
+                    }
+                    else if (line.FirstPoint.X == edgeNE.X) // First On East, look SOUTH
+                    {
+                        LookSouth(edgeSW, edgeNE, paths, line, line.FirstPoint);
+                    }
+                    else if (line.FirstPoint.Y == edgeSW.Y) // First On South, look WEST
+                    {
+                        LookWest(edgeSW, edgeNE, paths, line, line.FirstPoint);
+                    }
+                    else if (line.FirstPoint.X == edgeSW.X) // First On West, look North
+                    {
+                        LookNorth(edgeSW, edgeNE, paths, line, line.FirstPoint);
+                    }
+                }
+            }
+        }
+
+        private static void LookEast(TerrainPoint edgeSW, TerrainPoint edgeNE, IEnumerable<TerrainPath> notClosed, TerrainPath line, TerrainPoint lookFrom, int depth = 0)
+        {
+            var other = notClosed
+                .Where(n => !n.IsClosed && n.LastPoint.Y == edgeNE.Y && n.LastPoint.X > lookFrom.X)
+                .OrderBy(n => n.LastPoint.X)
+                .FirstOrDefault();
+            if (other == line)
+            {
+                line.Points.Add(line.FirstPoint);
+            }
+            else if (other == null && depth < 4)
+            {
+                line.Points.Insert(0, edgeNE);
+                LookSouth(edgeSW, edgeNE, notClosed, line, edgeNE, depth + 1);
+            }
+        }
+
+        private static void LookSouth(TerrainPoint edgeSW, TerrainPoint edgeNE, IEnumerable<TerrainPath> notClosed, TerrainPath line, TerrainPoint lookFrom, int depth = 0)
+        {
+            var other = notClosed
+                .Where(n => !n.IsClosed && n.LastPoint.X == edgeNE.X && n.LastPoint.Y < lookFrom.Y)
+                .OrderByDescending(n => n.LastPoint.Y)
+                .FirstOrDefault();
+            if (other == line)
+            {
+                line.Points.Add(line.FirstPoint);
+            }
+            else if (other == null && depth < 4)
+            {
+                var southEast = new TerrainPoint(edgeNE.X, edgeSW.Y);
+                line.Points.Insert(0, southEast);
+                LookWest(edgeSW, edgeNE, notClosed, line, southEast, depth + 1);
+            }
+        }
+
+        private static void LookWest(TerrainPoint edgeSW, TerrainPoint edgeNE, IEnumerable<TerrainPath> notClosed, TerrainPath line, TerrainPoint lookFrom, int depth = 0)
+        {
+            var other = notClosed
+                .Where(n => !n.IsClosed && n.LastPoint.Y == edgeSW.Y && n.LastPoint.X < lookFrom.X)
+                .OrderByDescending(n => n.LastPoint.X)
+                .FirstOrDefault();
+            if (other == line)
+            {
+                line.Points.Add(line.FirstPoint);
+            }
+            else if (other == null && depth < 4)
+            {
+                line.Points.Insert(0, edgeSW);
+                LookNorth(edgeSW, edgeNE, notClosed, line, edgeSW, depth + 1);
+            }
+        }
+
+        private static void LookNorth(TerrainPoint edgeSW, TerrainPoint edgeNE, IEnumerable<TerrainPath> notClosed, TerrainPath line, TerrainPoint lookFrom, int depth = 0)
+        {
+            var other = notClosed
+                .Where(n => !n.IsClosed && n.LastPoint.X == edgeSW.X && n.LastPoint.Y > lookFrom.Y)
+                .OrderBy(n => n.LastPoint.Y)
+                .FirstOrDefault();
+            if (other == line)
+            {
+                line.Points.Add(line.FirstPoint);
+            }
+            else if (other == null && depth < 4)
+            {
+                var northWest = new TerrainPoint(edgeSW.X, edgeNE.Y);
+                line.Points.Insert(0, northWest);
+                LookEast(edgeSW, edgeNE, notClosed, line, northWest, depth + 1);
+            }
+        }
+
+        internal List<TerrainPath> MergeOriented(List<TerrainPath> paths)
+        {
+            using var report = progress.CreateStep("Coastlines", paths.Count);
+            var todo = new HashSet<TerrainPath>(paths);
+            var result = new List<TerrainPath>();
+            foreach (var path in todo.ToList())
+            {
+               
+                if (todo.Contains(path))
+                {
+                    todo.Remove(path);
+                    
+                    result.Add(path);
+                    if (!path.IsClosed)
+                    {
+                        var other = GetMergeable(paths, todo, path);
+                        while (other != null)
+                        {
+                            todo.Remove(other);
+
+                           if (TerrainPoint.Equals(path.LastPoint, other.FirstPoint))
+                            {
+                                path.Points.AddRange(other.Points.Skip(1));
+                            }
+                            else
+                            {
+                                path.Points.InsertRange(0, other.Points.Take(other.Points.Count-1));
+                            }
+                            other = GetMergeable(paths, todo, path);
+                        }
+                    }
+                    report.ReportOneDone();
+                }
+                
+            }
+            return result;
+        }
+
+
+        private static TerrainPath? GetMergeable(List<TerrainPath> paths, HashSet<TerrainPath> todo, TerrainPath path)
+        {
+            return paths.FirstOrDefault(other => other != path && todo.Contains(other) && (TerrainPoint.Equals(other.LastPoint, path.FirstPoint) || TerrainPoint.Equals(other.FirstPoint, path.LastPoint)));
+        }
+
+
+
+    }
+}

--- a/GameRealisticMap/Nature/Ocean/OceanData.cs
+++ b/GameRealisticMap/Nature/Ocean/OceanData.cs
@@ -1,0 +1,24 @@
+﻿using GameRealisticMap.Geometries;
+using GeoJSON.Text.Feature;
+using GeoJSON.Text.Geometry;
+
+namespace GameRealisticMap.Nature.Ocean
+{
+    public class OceanData : IBasicTerrainData
+    {
+        public OceanData(List<TerrainPolygon> polygons)
+        {
+            Polygons = polygons;
+        }
+
+        public List<TerrainPolygon> Polygons { get; }
+
+        public IEnumerable<Feature> ToGeoJson(Func<TerrainPoint, IPosition> project)
+        {
+            var properties = new Dictionary<string, object>() {
+                {"type", "ocean" }
+            };
+            return Polygons.Select(b => new Feature(b.ToGeoJson(project), properties));
+        }
+    }
+}

--- a/GameRealisticMap/Nature/Ocean/OceanData.cs
+++ b/GameRealisticMap/Nature/Ocean/OceanData.cs
@@ -6,12 +6,15 @@ namespace GameRealisticMap.Nature.Ocean
 {
     public class OceanData : IBasicTerrainData
     {
-        public OceanData(List<TerrainPolygon> polygons)
+        public OceanData(List<TerrainPolygon> polygons, List<TerrainPolygon> land)
         {
             Polygons = polygons;
+            Land = land;
         }
 
         public List<TerrainPolygon> Polygons { get; }
+
+        public List<TerrainPolygon> Land { get; }
 
         public IEnumerable<Feature> ToGeoJson(Func<TerrainPoint, IPosition> project)
         {

--- a/GameRealisticMap/Nature/Ocean/OceanData.cs
+++ b/GameRealisticMap/Nature/Ocean/OceanData.cs
@@ -6,15 +6,17 @@ namespace GameRealisticMap.Nature.Ocean
 {
     public class OceanData : IBasicTerrainData
     {
-        public OceanData(List<TerrainPolygon> polygons, List<TerrainPolygon> land)
+        public OceanData(List<TerrainPolygon> polygons, List<TerrainPolygon> land, bool isIsland)
         {
             Polygons = polygons;
             Land = land;
+            IsIsland = isIsland;
         }
 
         public List<TerrainPolygon> Polygons { get; }
 
         public List<TerrainPolygon> Land { get; }
+        public bool IsIsland { get; }
 
         public IEnumerable<Feature> ToGeoJson(Func<TerrainPoint, IPosition> project)
         {

--- a/GameRealisticMap/Preview/PreviewRender.cs
+++ b/GameRealisticMap/Preview/PreviewRender.cs
@@ -77,6 +77,51 @@ namespace GameRealisticMap.Preview
             }
         }
 
+        public async Task RenderHtml<TData>(IProgressTask progress, string targetFile) 
+            where TData: class, IGeoJsonData
+        {
+            try
+            {
+                
+                var catalog = new BuildersCatalog(progress, library, null, true);
+                progress.Total = 3;
+
+                var loader = new OsmDataOverPassLoader(progress);
+                var osmSource = await loader.Load(terrainArea);
+                progress.ReportOneDone();
+                if (progress.CancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                var context = new BuildContext(catalog, progress, terrainArea, osmSource, imagery);
+                var list = new List<Feature>();
+                var data = context.GetData<TData>();
+                
+                list.AddRange(data.ToGeoJson(p => p));
+                progress.ReportOneDone();
+                if (progress.CancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                
+
+                var collection = new FeatureCollection(list);
+
+                await RenderHtml(collection, targetFile);
+
+                progress.ReportOneDone();
+            }
+            catch (Exception ex)
+            {
+                progress.Failed(ex);
+            }
+            finally
+            {
+                progress.Dispose();
+            }
+        }
+
         //private IPosition Project(TerrainPoint point)
         //{
         //    var p = terrainArea.TerrainPointToLatLng(point);

--- a/GameRealisticMap/Preview/grm-preview.js
+++ b/GameRealisticMap/Preview/grm-preview.js
@@ -480,6 +480,8 @@ function InitPreview(geoJson)
                 case 'fence': return { stroke: true, weight: 3, color: 'red' };
                 case 'tree': return { fillColor: "ForestGreen", stroke: false, fillOpacity: 0.8 };
                 case 'railway': return { fillColor: "black", stroke: false, fillOpacity: 0.8 };
+
+                case 'ocean': return { fillColor: 'RoyalBlue', fillOpacity: 0.5, stroke: true, weight: 3, color: 'RoyalBlue' };
 			}
 			return { fillColor:'black', stroke: false, fillOpacity: 0.2 };
         },

--- a/GameRealisticMap/Preview/grm-preview.js
+++ b/GameRealisticMap/Preview/grm-preview.js
@@ -482,6 +482,7 @@ function InitPreview(geoJson)
                 case 'railway': return { fillColor: "black", stroke: false, fillOpacity: 0.8 };
 
                 case 'ocean': return { fillColor: 'RoyalBlue', fillOpacity: 0.5, stroke: true, weight: 3, color: 'RoyalBlue' };
+                case 'coastline': return { stroke: true, weight: 1, dashArray: [5, 5], color: 'yellow', fillOpacity: 0 };
 			}
 			return { fillColor:'black', stroke: false, fillOpacity: 0.2 };
         },


### PR DESCRIPTION
- [x] Compute ocean polygon based on OpenStreetMap coastline
- [x] Use elevation from SRTM15+ for ocean depth and ensure depth below zero for ocean
- [x] Specific ocean ground material
  - By default, add sand on coastline on +/- 5 m (with a fade effect)
  - Low priority to allow manually mapped rock and sand area to be shown 
- [x] Use SRTM15+ / AW3D30 for regions not covered by SRTM1