### PR TITLE
Fix issues in path processing by ocean detection and sidewalk + optimization

### DIFF
--- a/GameRealisticMap/Geometries/MutableTerrainPath.cs
+++ b/GameRealisticMap/Geometries/MutableTerrainPath.cs
@@ -1,0 +1,32 @@
+﻿namespace GameRealisticMap.Geometries
+{
+    internal class MutableTerrainPath
+    {
+        public MutableTerrainPath(List<TerrainPoint> points)
+        {
+            this.Points = points;
+        }
+
+        public MutableTerrainPath(TerrainPath path)
+            : this(path.Points.ToList())
+        {
+
+        }
+
+        public List<TerrainPoint> Points { get; }
+
+        public TerrainPoint FirstPoint => Points[0];
+
+        public TerrainPoint LastPoint => Points[Points.Count - 1];
+
+        public float Length => TerrainPath.GetLength(Points);
+
+        public bool IsClosed => FirstPoint.Equals(LastPoint);
+
+        public TerrainPath ToPath()
+        {
+            return new TerrainPath(Points);
+        }
+
+    }
+}

--- a/GameRealisticMap/Geometries/TerrainPath.cs
+++ b/GameRealisticMap/Geometries/TerrainPath.cs
@@ -279,7 +279,9 @@ namespace GameRealisticMap.Geometries
                 }
                 else
                 {
-                    Debugger.Break();
+#if DEBUG
+                    throw new InvalidOperationException("Unsupported edge case");
+#endif
                 }
             }
             return clipped;

--- a/GameRealisticMap/ManMade/Roads/SidewalksBuilder.cs
+++ b/GameRealisticMap/ManMade/Roads/SidewalksBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using GameRealisticMap.Geometries;
 using GameRealisticMap.ManMade.Buildings;
 using GameRealisticMap.ManMade.Fences;
@@ -49,7 +50,7 @@ namespace GameRealisticMap.ManMade.Roads
 
             using (var report = progress.CreateStep("MergeRoads", polygons.Count))
             {
-                polygons = TerrainPolygon.MergeAll(polygons, report);
+                polygons = TerrainPolygon.MergeAllParallel(polygons, report);
             }
 
             var paths =
@@ -61,17 +62,45 @@ namespace GameRealisticMap.ManMade.Roads
                 .Where(p => p.Length > MinimalLength)
                 .ToList();
 
-            foreach(var path in paths.ProgressStep(progress, "Orientation"))
+            var result = new List<TerrainPath>();
+
+            foreach (var path in paths.ProgressStep(progress, "Orientation"))
             {
-                var dx = new TerrainPoint(Vector2.Transform(path.Points[0].Vector + (Vector2.Normalize(path.Points[1].Vector - path.Points[0].Vector) * (Epsilon)),
-                    Matrix3x2.CreateRotation(MathF.PI/2, path.Points[0].Vector)));
-                if (!polygons.Any(p => p.Contains(dx)))
+                var pathToUse = EnsureOrientation(polygons, path);
+                if (pathToUse != null)
                 {
-                    path.Points.Reverse();
+                    result.Add(pathToUse);
                 }
             }
 
-            return new SidewalksData(paths);
+            return new SidewalksData(result);
+        }
+
+        private static TerrainPath? EnsureOrientation(List<TerrainPolygon> polygons, TerrainPath path)
+        {
+            for (var index = 0; index < path.Points.Count - 1; index++)
+            {
+                var epsilonPoint = path.Points[index].Vector + (Vector2.Normalize(path.Points[index + 1].Vector - path.Points[index].Vector) * Epsilon);
+
+                var left = new TerrainPoint(Vector2.Transform(epsilonPoint, Matrix3x2.CreateRotation(MathF.PI / 2, path.Points[index].Vector)));
+                var right = new TerrainPoint(Vector2.Transform(epsilonPoint, Matrix3x2.CreateRotation(-MathF.PI / 2, path.Points[index].Vector)));
+
+                var leftInRoad = polygons.Any(p => p.Contains(left));
+                var rightInRoad = polygons.Any(p => p.Contains(right));
+
+                if (leftInRoad && !rightInRoad)
+                {
+                    // left is in road, all good
+                    return path;
+                }
+                if (rightInRoad && !leftInRoad)
+                {
+                    // left should be in a road, revering path will solve that
+                    return path.Reversed();
+                }
+                // none or both in road, will look at next point
+            }
+            return null;
         }
 
         private bool DoNotCrossSideWalk(IRoadTypeInfos roadTypeInfos)


### PR DESCRIPTION
`ClippedKeepOrientation` had too much unsupported edge cases, logic have been reworked to limit unsupported cases.

`OceanBuilder` was mutating path, but they should be immutable because some properties are not designed to be re-computed. Once all legacy code is removed, should switch to immutable lists or collections everywhere.

`SidewalkBuilder` was extremely slow, operations in `TerrainPath` have been optimized to avoid useless calls to ClipperLib.

`SidewalkBuilder` had some issue in sidewalk orientation detection as reported in comments in #94.
