### PR TITLE
Resilient map config loader

### DIFF
--- a/GameRealisticMap.Arma3/GameEngine/GameConfigTextData.cs
+++ b/GameRealisticMap.Arma3/GameEngine/GameConfigTextData.cs
@@ -9,6 +9,7 @@ namespace GameRealisticMap.Arma3.GameEngine
     public sealed class GameConfigTextData
     {
         public const string FileName = "config.cpp";
+        public const string FileNameRecover = "config-initial.hpp";
 
         private static readonly Regex WorldNameRegex = new Regex(@"worldName\s*=\s*""([^""]+)\.wrp""", RegexOptions.CultureInvariant|RegexOptions.IgnoreCase);
         private static readonly Regex DescriptionRegex = new Regex(@"description\s*=\s*""([^""]+)""", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/Views/Arma3WorldEditorView.xaml
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/Views/Arma3WorldEditorView.xaml
@@ -62,7 +62,7 @@
                         <Label Grid.Row="2" Grid.Column="0" Margin="5"><Run Text="{x:Static r:Labels.PboPrefix}"/></Label>
                         <TextBlock Grid.Row="2" Grid.Column="1" Margin="5" VerticalAlignment="Center">
                             <Hyperlink Command="{Binding OpenDirectoryCommand}">
-                                <TextBlock Text="{Binding HistoryEntry.PboPrefix}" />
+                                <TextBlock Text="{Binding ConfigFile.PboPrefix}" />
                             </Hyperlink>
                         </TextBlock>
 


### PR DESCRIPTION
Allows to open a world file even if GRM was/has stopped while calling Binarize