### PR TITLE
Include PNG files in Wrp rename/PboPrefix change to keep imagery features on new file

### DIFF
--- a/GameRealisticMap.Arma3.Test/Edit/WrpRenameWorkerTest.cs
+++ b/GameRealisticMap.Arma3.Test/Edit/WrpRenameWorkerTest.cs
@@ -147,5 +147,29 @@ class CfgWorlds
             Assert.Equal(@"FILE01", fs.ReadAllText("newprefix\\file01.paa"));
             Assert.Equal(@"FILE03", fs.ReadAllText("newprefix\\file03.paa"));
         }
+
+        [Fact]
+        public async Task CopyReferencedFiles_WithPng()
+        {
+            var fs = new GameFileSystemMock();
+            fs.CreateDirectory("oldprefix");
+            fs.WriteTextFile("oldprefix\\file01.paa", "FILE01");
+            fs.WriteTextFile("oldprefix\\file03.paa", "FILE03");
+            fs.WriteTextFile("oldprefix\\file03.png", "FILE03-PNG");
+            var worker = new WrpRenameWorker(new NoProgressSystem(), fs, "oldprefix", "newprefix");
+
+            worker.UpdateConfigContent(@" ""oldprefix\file01.paa"" ""other\file02.paa"" ""oldprefix\file03.paa"" "); // Only to add values into ReferencedFiles
+
+            Assert.Equal(3, worker.ReferencedFiles.Count());
+
+            await worker.CopyReferencedFiles();
+
+            Assert.Empty(worker.ReferencedFiles);
+
+            Assert.Equal(@"FILE01", fs.ReadAllText("newprefix\\file01.paa"));
+            Assert.Equal(@"FILE03", fs.ReadAllText("newprefix\\file03.paa"));
+            Assert.Equal(@"FILE03-PNG", fs.ReadAllText("newprefix\\file03.png"));
+        }
+
     }
 }

--- a/GameRealisticMap.Arma3/Edit/WrpRenameWorker.cs
+++ b/GameRealisticMap.Arma3/Edit/WrpRenameWorker.cs
@@ -60,7 +60,18 @@ namespace GameRealisticMap.Arma3.Edit
         {
             foreach (Match entry in oldPboPrefixRegex.Matches(content))
             {
-                filesToCopy[entry.Groups[1].Value] = @$"{newPboPrefix}\{entry.Groups[2].Value}";
+                var oldName = entry.Groups[1].Value;
+                var newName = @$"{newPboPrefix}\{entry.Groups[2].Value}";
+                filesToCopy[oldName] = newName;
+                if (oldName.EndsWith(".paa", StringComparison.OrdinalIgnoreCase))
+                {
+                    var oldPng = Path.ChangeExtension(oldName, ".png");
+                    if (writer.FileExists(oldPng))
+                    {
+                        var newPng = Path.ChangeExtension(newName, ".png");
+                        filesToCopy[oldPng] = newPng;
+                    }
+                }
             }
             content = oldPboPrefixRegex.Replace(content, e => @$"""{newPboPrefix}\{e.Groups[2].Value}""");
             return content;


### PR DESCRIPTION
The imagery editor required PNG files to be present, but the Wrp rename/PboPrefix change only copied PAA files.