### PR TITLE
Empty textures or models should not fail at UnpackModels

### DIFF
--- a/GameRealisticMap.Arma3/Edit/SimpleWrpModGenerator.cs
+++ b/GameRealisticMap.Arma3/Edit/SimpleWrpModGenerator.cs
@@ -40,7 +40,7 @@ namespace GameRealisticMap.Arma3.Edit
             {
                 foreach (var model in usedModels)
                 {
-                    if (!projectDrive.EnsureLocalFileCopy(model))
+                    if (!projectDrive.EnsureLocalFileCopy(model) && !string.IsNullOrWhiteSpace(model))
                     {
                         throw new ApplicationException($"File '{model}' is missing. Have you added all required mods in application configuration?");
                     }

--- a/GameRealisticMap.Arma3/GameEngine/DependencyUnpacker.cs
+++ b/GameRealisticMap.Arma3/GameEngine/DependencyUnpacker.cs
@@ -48,7 +48,7 @@ namespace GameRealisticMap.Arma3.GameEngine
             using var report = progress.CreateInteger("UnpackFiles", files.Count);
             foreach (var model in files)
             {
-                if (!projectDrive.EnsureLocalFileCopy(model))
+                if (!projectDrive.EnsureLocalFileCopy(model) && !string.IsNullOrWhiteSpace(model))
                 {
                     throw new ApplicationException($"File '{model}' is missing. Have you added all required mods in application configuration?");
                 }


### PR DESCRIPTION
Empty entries create strange error messages at UnpackModels, avoid to fail here.

Fix  #247