### PR TITLE
Adjust export page size

### DIFF
--- a/@ArmaMapStudio/addons/eden/functions/fnc_export.sqf
+++ b/@ArmaMapStudio/addons/eden/functions/fnc_export.sqf
@@ -109,8 +109,11 @@ private _results = [];
 
 toFixed 20; 
 
-for "_i" from 0 to (count _data) step 20000 do { 
-	_results pushBack (([_prelude] + (_data select [_i, 20000])) joinString endl);
+// 10 000 000 max bytes
+// 550 bytes max  per line
+// => 18 000 lines per page
+for "_i" from 0 to (count _data) step 18000 do { 
+	_results pushBack (([_prelude] + (_data select [_i, 18000])) joinString endl);
 };
 
 toFixed -1; 

--- a/@ArmaMapStudio/addons/main/script_version.hpp
+++ b/@ArmaMapStudio/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 0
 #define MINOR 3
-#define PATCH 2
+#define PATCH 3
 #define BUILD 0


### PR DESCRIPTION
Export page size was based on 500 bytes per export line, but actual values are sometime above this value.
Assuming elevation above 1000 or lower than 999, export would be 525 bytes par line.
Now assume a maximum of 550 bytes par export line, so export page size was lowered to 18000

Fixes #274