### PR TITLE
Allow to remove objects from GRM editor

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -70,7 +70,7 @@ jobs:
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload MSIX Test Package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MSIX Test Package
         path: ${{ env.Wap_Project_Directory }}\AppPackages\*_Test

--- a/.github/workflows/dotnet-linux.yml
+++ b/.github/workflows/dotnet-linux.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet publish --no-self-contained -f net8.0 -r linux-x64 -c Release GameRealisticMap.Arma3.CommandLine/GameRealisticMap.Arma3.CommandLine.csproj -o Output
       
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Linux Command Line
         path: Output/grma3

--- a/GameRealisticMap.Studio/Controls/GrmMapArma3.cs
+++ b/GameRealisticMap.Studio/Controls/GrmMapArma3.cs
@@ -4,7 +4,6 @@ using System.Numerics;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using Caliburn.Micro;
 using GameRealisticMap.Arma3.GameEngine.Roads;
 using GameRealisticMap.Geometries;
@@ -178,18 +177,23 @@ namespace GameRealisticMap.Studio.Controls
             {
                 var objects = Objects;
                 var roads = Roads;
-                if (roads != null)
+                if (roads != null || objects != null)
                 {
                     var coordinates = ParentMap!.ViewportCoordinates(e.GetPosition(ParentMap));
                     var enveloppe = new Envelope(coordinates - new Vector2(5), coordinates + new Vector2(5));
 
-                    var selection = (object?)roads.Roads
-                        .Where(r => !r.IsRemoved && r.Path.EnveloppeIntersects(enveloppe))
-                        .Select(r => (road: r, distance: r.Path.Distance(coordinates)))
-                        .Where(r => r.distance < r.road.RoadTypeInfos.TextureWidth / 2)
-                        .OrderBy(r => r.distance)
-                        .Select(r => r.road)
-                        .FirstOrDefault();
+                    object? selection = null;
+
+                    if (roads != null)
+                    {
+                        selection = roads.Roads
+                            .Where(r => !r.IsRemoved && r.Path.EnveloppeIntersects(enveloppe))
+                            .Select(r => (road: r, distance: r.Path.Distance(coordinates)))
+                            .Where(r => r.distance < r.road.RoadTypeInfos.TextureWidth / 2)
+                            .OrderBy(r => r.distance)
+                            .Select(r => r.road)
+                            .FirstOrDefault();
+                    }
 
                     if (selection == null && objects != null)
                     {

--- a/GameRealisticMap.Studio/Controls/GrmMapArma3.cs
+++ b/GameRealisticMap.Studio/Controls/GrmMapArma3.cs
@@ -80,7 +80,7 @@ namespace GameRealisticMap.Studio.Controls
                     var mode = AerialViewMode;
                     foreach (var obj in objs.Search(enveloppe))
                     {
-                        if (scale * obj.Radius > 15)
+                        if (scale * obj.Radius > 15 && !obj.IsRemoved)
                         {
                             dc.PushTransform(obj.Matrix.ToAerialWpfMatrixTransform());
 
@@ -139,10 +139,10 @@ namespace GameRealisticMap.Studio.Controls
             switch (obj.Category)
             {
                 case AssetCatalogCategory.Tree:
-                    dc.DrawEllipse(null, new Pen(tree, 0.2), new Point(), obj.Rectangle.Width, obj.Rectangle.Height);
+                    dc.DrawEllipse(null, new Pen(tree, 0.2), new Point(), obj.Rectangle.Width / 2, obj.Rectangle.Height / 2);
                     break;
                 case AssetCatalogCategory.Bush:
-                    dc.DrawEllipse(null, new Pen(bush, 0.2), new Point(), obj.Rectangle.Width, obj.Rectangle.Height);
+                    dc.DrawEllipse(null, new Pen(bush, 0.2), new Point(), obj.Rectangle.Width / 2, obj.Rectangle.Height / 2);
                     break;
                 case AssetCatalogCategory.WaterSurface:
                     dc.DrawRectangle(null, new Pen(water, 0.2), obj.Rectangle);
@@ -158,10 +158,10 @@ namespace GameRealisticMap.Studio.Controls
             switch (obj.Category)
             {
                 case AssetCatalogCategory.Tree:
-                    dc.DrawEllipse(tree, null, new Point(), obj.Rectangle.Width, obj.Rectangle.Height);
+                    dc.DrawEllipse(tree, null, new Point(), obj.Rectangle.Width / 2, obj.Rectangle.Height / 2);
                     break;
                 case AssetCatalogCategory.Bush:
-                    dc.DrawEllipse(bush, null, new Point(), obj.Rectangle.Width, obj.Rectangle.Height);
+                    dc.DrawEllipse(bush, null, new Point(), obj.Rectangle.Width/2, obj.Rectangle.Height / 2);
                     break;
                 case AssetCatalogCategory.WaterSurface:
                     dc.DrawRectangle(water, null, obj.Rectangle);
@@ -176,13 +176,14 @@ namespace GameRealisticMap.Studio.Controls
         {
             if (e.Source == this && e.ClickCount == 1)
             {
+                var objects = Objects;
                 var roads = Roads;
                 if (roads != null)
                 {
                     var coordinates = ParentMap!.ViewportCoordinates(e.GetPosition(ParentMap));
                     var enveloppe = new Envelope(coordinates - new Vector2(5), coordinates + new Vector2(5));
 
-                    var editRoad = roads.Roads
+                    var selection = (object?)roads.Roads
                         .Where(r => !r.IsRemoved && r.Path.EnveloppeIntersects(enveloppe))
                         .Select(r => (road: r, distance: r.Path.Distance(coordinates)))
                         .Where(r => r.distance < r.road.RoadTypeInfos.TextureWidth / 2)
@@ -190,13 +191,24 @@ namespace GameRealisticMap.Studio.Controls
                         .Select(r => r.road)
                         .FirstOrDefault();
 
+                    if (selection == null && objects != null)
+                    {
+                        selection = objects.Search(enveloppe)
+                            .Where(o => !o.IsRemoved)
+                            .Select(r => (obj: r, distance: (r.Center.Vector - coordinates.Vector).Length()))
+                            .OrderBy(r => r.distance)
+                            .Where(r => r.distance < r.obj.Radius)
+                            .Select(r => r.obj)
+                            .FirstOrDefault();
+                    }
+
                     if (Keyboard.Modifiers == ModifierKeys.Control)
                     {
-                        AddToSelectionCommand?.Execute(editRoad);
+                        AddToSelectionCommand?.Execute(selection);
                     }
                     else
                     {
-                        SelectItem?.Execute(editRoad);
+                        SelectItem?.Execute(selection);
                     }
                     e.Handled = true;
                 }

--- a/GameRealisticMap.Studio/Controls/GrmMapEditLayer.cs
+++ b/GameRealisticMap.Studio/Controls/GrmMapEditLayer.cs
@@ -361,13 +361,19 @@ namespace GameRealisticMap.Studio.Controls
                         Command = new RelayCommand(_ => ContinuePathFrom(square))
                     });
                 }
-                menu.Items.Add(new MenuItem()
+                if (editPoints.CanDeletePoint)
                 {
-                    Header = "Delete point",
-                    Icon = new Image() { Source = new BitmapImage(new Uri("pack://application:,,,/GameRealisticMap.Studio;component/Resources/Tools/bin.png")) },
-                    Command = new RelayCommand(_ => PointPositionDelete(square))
-                });
-                ButtonBehaviors.ShowButtonContextMenu(square, menu);
+                    menu.Items.Add(new MenuItem()
+                    {
+                        Header = "Delete point",
+                        Icon = new Image() { Source = new BitmapImage(new Uri("pack://application:,,,/GameRealisticMap.Studio;component/Resources/Tools/bin.png")) },
+                        Command = new RelayCommand(_ => PointPositionDelete(square))
+                    });
+                }
+                if (menu.Items.Count > 0)
+                {
+                    ButtonBehaviors.ShowButtonContextMenu(square, menu);
+                }
             }
         }
 
@@ -474,6 +480,10 @@ namespace GameRealisticMap.Studio.Controls
             if (segment.Count == 0)
             {
                 return false;
+            }
+            if (segment is IEditablePointCollection a && a.IsObjectSquare)
+            {
+                return new TerrainPolygon(segment.Take(4).ToList()).Contains(point);
             }
             if (segment.Count == 1)
             {

--- a/GameRealisticMap.Studio/Controls/GrmMapEditLayerOverlay.cs
+++ b/GameRealisticMap.Studio/Controls/GrmMapEditLayerOverlay.cs
@@ -48,10 +48,26 @@ namespace GameRealisticMap.Studio.Controls
                 if (segment.Count > 0)
                 {
                     var points = segment.Select(p => parentMap.ProjectViewport(p)).ToList();
-                    
-                    dc.DrawGeometry(null, pen, CreateGeometry(points));
-                    dc.DrawRectangle(brush, null, new Rect(((Point)(points[0] - new Point(3, 3))), new Size(6, 6)));
-                    dc.DrawRectangle(brush, null, new Rect(((Point)(points[points.Count-1] - new Point(3, 3))), new Size(6, 6)));
+
+                    if (segment is IEditablePointCollection a && a.IsObjectSquare)
+                    {
+                        foreach (var point in points)
+                        {
+                            dc.DrawRectangle(brush, null, new Rect(((Point)(point - new Point(3, 3))), new Size(6, 6)));
+                        }
+                        if (points.Count == 5)
+                        {
+                            points.RemoveAt(4);
+                        }
+                        points.Add(points[0]);
+                        dc.DrawGeometry(null, pen, CreateGeometry(points));
+                      }
+                    else
+                    {
+                        dc.DrawGeometry(null, pen, CreateGeometry(points));
+                        dc.DrawRectangle(brush, null, new Rect(((Point)(points[0] - new Point(3, 3))), new Size(6, 6)));
+                        dc.DrawRectangle(brush, null, new Rect(((Point)(points[points.Count - 1] - new Point(3, 3))), new Size(6, 6)));
+                    }
                 }
             }
         }
@@ -70,6 +86,14 @@ namespace GameRealisticMap.Studio.Controls
                 {
                     points.Insert(0, previewInsertPoint);
                 }
+            }
+            if (source.IsObjectSquare)
+            {
+                if (points.Count == 5)
+                {
+                    points.RemoveAt(4);
+                }
+                points.Add(points[0]);
             }
             return CreateGeometry(points);
         }

--- a/GameRealisticMap.Studio/Controls/IEditablePointCollection.cs
+++ b/GameRealisticMap.Studio/Controls/IEditablePointCollection.cs
@@ -11,6 +11,8 @@ namespace GameRealisticMap.Studio.Controls
 
         bool CanInsertBetween { get; }
 
+        bool CanDeletePoint { get; }
+
         void Insert(int index, TerrainPoint terrainPoint);
 
         void RemoveAt(int index);
@@ -26,5 +28,7 @@ namespace GameRealisticMap.Studio.Controls
         void SplitAt(int index);
 
         void Remove();
+
+        bool IsObjectSquare { get; }
     }
 }

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldEditorViewModel.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldEditorViewModel.cs
@@ -289,7 +289,7 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
         { 
             get { return isRoadsDirty; } 
             set { isRoadsDirty = value; if (value) { IsDirty = true; } } 
-        } 
+        }
 
         public EditableArma3Roads? Roads 
         { 
@@ -356,7 +356,11 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
             if (IsDirty)
             {
                 worldBackup.CreateBackup(filePath, savedRevision, GetBackupFiles(filePath));
-                StreamHelper.Write(World, filePath);
+
+                var world = World;
+                world!.Objects = GetActualObjects();
+                StreamHelper.Write(world, filePath);
+
                 UpdateBackupsList(filePath);
             }
             if (ConfigFile != null)
@@ -795,6 +799,19 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
         public ExistingImageryInfos GetConfig()
         {
             return Imagery ?? new ExistingImageryInfos(0, 0, 0, ConfigFile?.PboPrefix ?? string.Empty);
+        }
+
+        public List<EditableWrpObject> GetActualObjects()
+        {
+            if (World != null)
+            {
+                if (mapEditor != null)
+                {
+                    return mapEditor.GetActualObjects();
+                }
+                return World.Objects;
+            }
+            return new List<EditableWrpObject>();
         }
     }
 }

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldEditorViewModel.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldEditorViewModel.cs
@@ -201,7 +201,7 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
                 NotifyOfPropertyChange(); 
                 NotifyOfPropertyChange(nameof(Size));
                 UpdateObjectStats();
-                mapEditor?.InvalidateObjects();
+                mapEditor?.InvalidateObjects(true);
             }
         }
 

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldMapViewModel.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldMapViewModel.cs
@@ -360,12 +360,20 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
             await base.OnInitializeAsync(cancellationToken);
         }
 
-        internal void InvalidateObjects()
+        internal void InvalidateObjects(bool clearHistory = false)
         {
             // Primary list had a mass change, invalidate our copy
             initialList = null;
             Objects = null;
             NotifyOfPropertyChange(nameof(Objects));
+
+            if (clearHistory)
+            {  
+                // We loaded an old version of the world, clear undo/redo history
+                UndoRedoManager.UndoCountLimit = 0;
+                UndoRedoManager.UndoCountLimit = null;
+                objCache.Clear();
+            }
 
             // Load again
             _ = Task.Run(DoLoadWorld);

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldMapViewModel.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/Arma3WorldMapViewModel.cs
@@ -12,6 +12,7 @@ using GameRealisticMap.Geometries;
 using GameRealisticMap.Studio.Controls;
 using GameRealisticMap.Studio.Modules.Arma3Data;
 using GameRealisticMap.Studio.Modules.AssetBrowser.Services;
+using GameRealisticMap.Studio.UndoRedo;
 using Gemini.Framework;
 using Gemini.Framework.Commands;
 using Gemini.Modules.Inspector;
@@ -368,10 +369,9 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
             NotifyOfPropertyChange(nameof(Objects));
 
             if (clearHistory)
-            {  
+            {
                 // We loaded an old version of the world, clear undo/redo history
-                UndoRedoManager.UndoCountLimit = 0;
-                UndoRedoManager.UndoCountLimit = null;
+                UndoRedoManager.Clear();
                 objCache.Clear();
             }
 
@@ -428,8 +428,7 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
             cache.Clear();
 
             // Clear Undo/Redo history
-            UndoRedoManager.UndoCountLimit = 0;
-            UndoRedoManager.UndoCountLimit = null;
+            UndoRedoManager.Clear();
 
             var roads = Roads;
             if (roads != null)

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/EditRoadEditablePointCollection.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/EditRoadEditablePointCollection.cs
@@ -149,5 +149,9 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
                 }
             }
         }
+
+        public bool CanDeletePoint => true;
+
+        public bool IsObjectSquare => false;
     }
 }

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/RemoveObjectAction.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/RemoveObjectAction.cs
@@ -1,0 +1,31 @@
+﻿using Gemini.Modules.UndoRedo;
+
+namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
+{
+    internal class RemoveObjectAction : IUndoableAction
+    {
+        private Arma3WorldMapViewModel owner;
+        private TerrainObjectVM obj;
+
+        public RemoveObjectAction(Arma3WorldMapViewModel owner, TerrainObjectVM obj)
+        {
+            this.owner = owner;
+            this.obj = obj;
+        }
+
+        public string Name => $"Remove '{obj.Model}'";
+
+        public void Execute()
+        {
+            owner.EditPoints = obj;
+            obj.IsRemoved = true;
+        }
+
+        public void Undo()
+        {
+            owner.EditPoints = obj;
+            obj.IsRemoved = false;
+            owner.SelectItem(obj);
+        }
+    }
+}

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/TerrainObjectVM.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/TerrainObjectVM.cs
@@ -19,8 +19,8 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
     {
         private bool isRemoved;
         private IEnumerable<IInspector>? inspectors;
-        private readonly EditableWrpObject obj;
-        private readonly IAssetCatalogItem modelInfo;
+        private EditableWrpObject obj;
+        private IAssetCatalogItem modelInfo;
         private readonly Arma3WorldMapViewModel owner;
 
         private readonly List<TerrainPoint> corners = new List<TerrainPoint>();
@@ -63,11 +63,11 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
 
         public TerrainPoint Center => new TerrainPoint(obj.Transform.Matrix.M41, obj.Transform.Matrix.M43);
 
-        public float Radius { get; }
+        public float Radius { get; set; }
 
         public AssetCatalogCategory Category => modelInfo.Category;
 
-        public Rect Rectangle { get; }
+        public Rect Rectangle { get; set; }
 
         public string Model 
         { 
@@ -167,5 +167,20 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        internal void Update(IAssetCatalogItem modelInfo)
+        {
+            this.modelInfo = modelInfo;
+
+            Radius = Math.Max(new Vector2(modelInfo.BboxMin.X, modelInfo.BboxMin.Z).Length(), new Vector2(modelInfo.BboxMax.X, modelInfo.BboxMax.Z).Length());
+
+            Rectangle = new Rect(
+                modelInfo.BboxMin.X,
+                modelInfo.BboxMin.Z,
+                modelInfo.BboxMax.X - modelInfo.BboxMin.X,
+                modelInfo.BboxMax.Z - modelInfo.BboxMin.Z);
+
+            IsRemoved = false;
+        }
     }
 }

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/TerrainObjectVM.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/TerrainObjectVM.cs
@@ -180,6 +180,8 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
                 modelInfo.BboxMax.X - modelInfo.BboxMin.X,
                 modelInfo.BboxMax.Z - modelInfo.BboxMin.Z);
 
+            corners.Clear();
+
             IsRemoved = false;
         }
     }

--- a/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/TerrainObjectVM.cs
+++ b/GameRealisticMap.Studio/Modules/Arma3WorldEditor/ViewModels/TerrainObjectVM.cs
@@ -1,30 +1,59 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
 using System.Numerics;
 using System.Windows;
 using BIS.WRP;
+using Caliburn.Micro;
 using GameRealisticMap.Geometries;
+using GameRealisticMap.Studio.Controls;
 using GameRealisticMap.Studio.Modules.AssetBrowser.Services;
+using Gemini.Modules.Inspector;
+using Gemini.Modules.Inspector.Inspectors;
 
 namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
 {
-    public class TerrainObjectVM : ITerrainEnvelope
+    public class TerrainObjectVM : PropertyChangedBase, ITerrainEnvelope, IEditablePointCollection, IInspectableObject
     {
+        private bool isRemoved;
+        private IEnumerable<IInspector>? inspectors;
         private readonly EditableWrpObject obj;
         private readonly IAssetCatalogItem modelInfo;
+        private readonly Arma3WorldMapViewModel owner;
 
-        public TerrainObjectVM(EditableWrpObject obj, IAssetCatalogItem modelInfo)
+        private readonly List<TerrainPoint> corners = new List<TerrainPoint>();
+
+        internal TerrainObjectVM(Arma3WorldMapViewModel owner, EditableWrpObject obj, IAssetCatalogItem modelInfo)
         {
             this.obj = obj;
             this.modelInfo = modelInfo;
+            this.owner = owner;
 
             Radius = Math.Max(new Vector2(modelInfo.BboxMin.X, modelInfo.BboxMin.Z).Length(), new Vector2(modelInfo.BboxMax.X, modelInfo.BboxMax.Z).Length());
 
             Rectangle = new Rect(
-                modelInfo.BboxMin.X, 
+                modelInfo.BboxMin.X,
                 modelInfo.BboxMin.Z,
                 modelInfo.BboxMax.X - modelInfo.BboxMin.X,
-                modelInfo.BboxMax.Z - modelInfo.BboxMin.Z); 
+                modelInfo.BboxMax.Z - modelInfo.BboxMin.Z);
         }
+
+        private void GenerateCorners(EditableWrpObject obj, IAssetCatalogItem modelInfo)
+        {
+            corners.Add(ToTerrainPoint(Vector3.Transform(new Vector3(modelInfo.BboxMin.X, 0, modelInfo.BboxMin.Z), obj.Transform.Matrix)));
+            corners.Add(ToTerrainPoint(Vector3.Transform(new Vector3(modelInfo.BboxMin.X, 0, modelInfo.BboxMax.Z), obj.Transform.Matrix)));
+            corners.Add(ToTerrainPoint(Vector3.Transform(new Vector3(modelInfo.BboxMax.X, 0, modelInfo.BboxMax.Z), obj.Transform.Matrix)));
+            corners.Add(ToTerrainPoint(Vector3.Transform(new Vector3(modelInfo.BboxMax.X, 0, modelInfo.BboxMin.Z), obj.Transform.Matrix)));
+        }
+
+        private TerrainPoint ToTerrainPoint(Vector3 vector3)
+        {
+            return new TerrainPoint(vector3.X, vector3.Z);
+        }
+
+        internal EditableWrpObject WrpObject => obj;
 
         public Matrix4x4 Matrix => obj.Transform.Matrix;
 
@@ -40,6 +69,103 @@ namespace GameRealisticMap.Studio.Modules.Arma3WorldEditor.ViewModels
 
         public Rect Rectangle { get; }
 
-        public string Model => obj.Model;
+        public string Model 
+        { 
+            get => obj.Model; 
+            set { /* Not yet supported */ } 
+        }
+
+        public bool IsRemoved 
+        {
+            get { return isRemoved; } 
+            set 
+            {
+                if (isRemoved != value)
+                {
+                    isRemoved = value;
+                    NotifyOfPropertyChange();
+                    CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                    owner.MakeObjectsDirty();
+                }
+            }
+        }
+
+        public IEnumerable<IInspector> Inspectors 
+        {
+            get
+            {
+                if (inspectors == null)
+                {
+                    inspectors =
+                        new InspectableObjectBuilder()
+                            .WithEditor(this, r => r.Model, new TextBoxEditorViewModel<string>())
+                            .ToInspectableObject()
+                            .Inspectors;
+                }
+                return inspectors;
+            }
+         }
+
+        public bool CanInsertAtEnds => false;
+
+        public bool CanInsertBetween => false;
+
+        public bool CanSplit => false;
+
+        public int Count => isRemoved ? 0 : 4;
+
+        public bool CanDeletePoint => false;
+
+        public bool IsObjectSquare => true;
+
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        public void Add(TerrainPoint terrainPoint)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public IEnumerator<TerrainPoint> GetEnumerator()
+        {
+            if (isRemoved)
+            {
+                return Enumerable.Empty<TerrainPoint>().GetEnumerator();
+            }
+            if (corners.Count == 0)
+            {
+                GenerateCorners(obj, modelInfo);
+            }
+            return corners.GetEnumerator();
+        }
+
+        public void Insert(int index, TerrainPoint terrainPoint)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public void PreviewSet(int index, TerrainPoint value)
+        {
+        }
+
+        public void Remove()
+        {
+            owner.UndoRedoManager.ExecuteAction(new RemoveObjectAction(owner, this));
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public void Set(int index, TerrainPoint oldValue, TerrainPoint newValue)
+        {
+        }
+
+        public void SplitAt(int index)
+        {
+            throw new InvalidOperationException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/GameRealisticMap.Studio/UndoRedo/UndoRedoManagerExtensions.cs
+++ b/GameRealisticMap.Studio/UndoRedo/UndoRedoManagerExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Gemini.Modules.UndoRedo;
+
+namespace GameRealisticMap.Studio.UndoRedo
+{
+    public static class UndoRedoManagerExtensions
+    {
+
+        public static void Clear(this IUndoRedoManager undoRedoManager)
+        {
+            undoRedoManager.UndoCountLimit = 0;
+            undoRedoManager.UndoCountLimit = null;
+        }
+    }
+}


### PR DESCRIPTION
Some objects like decals cannot be edited using Eden Editor (in-game editor).
Provides a way to remove such objects