### PR TITLE
Upgrade legacy endpoints

### DIFF
--- a/GameRealisticMap.Test/Configuration/SourceLocationsTest.cs
+++ b/GameRealisticMap.Test/Configuration/SourceLocationsTest.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using GameRealisticMap.Configuration;
+
+namespace GameRealisticMap.Test.Configuration
+{
+    public class SourceLocationsTest
+    {
+        // ── helpers ──────────────────────────────────────────────────────────
+
+        private static SourceLocationsJson RoundTrip(SourceLocationsJson original)
+        {
+            var json = JsonSerializer.Serialize(original);
+            return JsonSerializer.Deserialize<SourceLocationsJson>(json)!;
+        }
+
+        private static SourceLocationsJson MakeDefaults(int configVersion = 1)
+        {
+            var d = DefaultSourceLocations.Instance;
+            return new SourceLocationsJson(
+                d.MapToolkitSRTM15Plus,
+                d.MapToolkitSRTM1,
+                d.MapToolkitAW3D30,
+                d.WeatherStats,
+                d.OverpassApiInterpreter,
+                configVersion: configVersion);
+        }
+
+        // ── ConfigVersion round-trip ─────────────────────────────────────────
+
+        [Fact]
+        public void ConfigVersion_IsSerializedAndDeserialized()
+        {
+            var original = MakeDefaults(configVersion: 1);
+            var restored = RoundTrip(original);
+            Assert.Equal(1, restored.ConfigVersion);
+        }
+
+        [Fact]
+        public void ConfigVersion_DefaultsToZeroWhenAbsentFromJson()
+        {
+            // JSON without a configVersion field
+            const string json = """
+                {
+                    "mapToolkitSRTM15Plus": "https://cdn.dem.pmad.net/SRTM15Plus/",
+                    "mapToolkitSRTM1":      "https://cdn.dem.pmad.net/SRTM1/",
+                    "mapToolkitAW3D30":     "https://cdn.dem.pmad.net/AW3D30/",
+                    "weatherStats":         "https://weatherdata.pmad.net/ERA5AVG/",
+                    "overpassApiInterpreter":"https://overpass.pmad.net/api/interpreter",
+                    "satelliteImageProvider":"https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2020_3857/default/GoogleMapsCompatible/15/{y}/{x}.jpg"
+                }
+                """;
+
+            var restored = JsonSerializer.Deserialize<SourceLocationsJson>(json)!;
+            Assert.Equal(0, restored.ConfigVersion);
+        }
+
+        // ── Migration: old → new endpoints ──────────────────────────────────
+
+        [Theory]
+        [InlineData("https://dem.pmad.net/SRTM15Plus/",  "https://cdn.dem.pmad.net/SRTM15Plus/")]
+        [InlineData("https://dem.pmad.net/SRTM1/",       "https://cdn.dem.pmad.net/SRTM1/")]
+        [InlineData("https://dem.pmad.net/AW3D30/",      "https://cdn.dem.pmad.net/AW3D30/")]
+        [InlineData("https://overpass-api.de/api/interpreter", "https://overpass.pmad.net/api/interpreter")]
+        public async Task Load_MigratesOldEndpoints(string oldUrl, string expectedUrl)
+        {
+            var d = DefaultSourceLocations.Instance;
+
+            // Build a JSON whose version is 0 and one of the endpoints is the old URL
+            var source = new SourceLocationsJson(
+                mapToolkitSRTM15Plus:    oldUrl.Contains("SRTM15") ? new Uri(oldUrl) : d.MapToolkitSRTM15Plus,
+                mapToolkitSRTM1:         oldUrl.Contains("SRTM1/") ? new Uri(oldUrl) : d.MapToolkitSRTM1,
+                mapToolkitAW3D30:        oldUrl.Contains("AW3D30") ? new Uri(oldUrl) : d.MapToolkitAW3D30,
+                weatherStats:            d.WeatherStats,
+                overpassApiInterpreter:  oldUrl.Contains("overpass") ? new Uri(oldUrl) : d.OverpassApiInterpreter,
+                configVersion: 0);
+
+            var path = Path.GetTempFileName();
+            try
+            {
+                await using (var stream = File.Create(path))
+                    await JsonSerializer.SerializeAsync(stream, source);
+
+                // Temporarily redirect DefaultLocation by reading the file directly
+                // (same code path as SourceLocations.Load but with a custom path)
+                await using var readStream = File.OpenRead(path);
+                var json = await JsonSerializer.DeserializeAsync<SourceLocationsJson>(readStream);
+                Assert.NotNull(json);
+
+                // Invoke the migration via the internal helper through round-trip Save/Load
+                // by saving to a temp location and reloading.
+                var migrated = await SourceLocations.Load(path);
+
+                var actual = oldUrl.Contains("SRTM15") ? migrated.MapToolkitSRTM15Plus
+                           : oldUrl.Contains("SRTM1/") ? migrated.MapToolkitSRTM1
+                           : oldUrl.Contains("AW3D30") ? migrated.MapToolkitAW3D30
+                           : migrated.OverpassApiInterpreter;
+
+                Assert.Equal(new Uri(expectedUrl), actual);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task Load_DoesNotMigrateWhenVersionIsCurrent()
+        {
+            // Already-migrated file: version = 1, endpoints are already new
+            var d = DefaultSourceLocations.Instance;
+            var source = MakeDefaults(configVersion: 1);
+
+            var path = Path.GetTempFileName();
+            try
+            {
+                await using (var stream = File.Create(path))
+                    await JsonSerializer.SerializeAsync(stream, source);
+
+                var loaded = await SourceLocations.Load(path);
+
+                Assert.Equal(d.MapToolkitSRTM15Plus, loaded.MapToolkitSRTM15Plus);
+                Assert.Equal(d.MapToolkitSRTM1,      loaded.MapToolkitSRTM1);
+                Assert.Equal(d.MapToolkitAW3D30,     loaded.MapToolkitAW3D30);
+                Assert.Equal(d.OverpassApiInterpreter, loaded.OverpassApiInterpreter);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async Task Load_ReturnsDefaultWhenFileDoesNotExist()
+        {
+            var loaded = await SourceLocations.Load(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json"));
+            Assert.Same(DefaultSourceLocations.Instance, loaded);
+        }
+
+        // ── Save stamps CurrentConfigVersion ────────────────────────────────
+
+        [Fact]
+        public async Task Save_StampsCurrentConfigVersion()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                await SourceLocations.Save(path, DefaultSourceLocations.Instance);
+
+                await using var stream = File.OpenRead(path);
+                var json = await JsonSerializer.DeserializeAsync<SourceLocationsJson>(stream);
+                Assert.NotNull(json);
+                Assert.True(json!.ConfigVersion > 0, "ConfigVersion should be stamped as > 0 after Save.");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/GameRealisticMap/Configuration/DefaultSourceLocations.cs
+++ b/GameRealisticMap/Configuration/DefaultSourceLocations.cs
@@ -1,18 +1,21 @@
 ﻿namespace GameRealisticMap.Configuration
 {
+    /// <summary>
+    /// Default values for <see cref="ISourceLocations"/>, used if no user configuration file is found.
+    /// </summary>
     public class DefaultSourceLocations : ISourceLocations
     {
         public static readonly ISourceLocations Instance = new DefaultSourceLocations();
 
-        public Uri MapToolkitSRTM15Plus => new Uri("https://dem.pmad.net/SRTM15Plus/");
+        public Uri MapToolkitSRTM15Plus => new Uri("https://cdn.dem.pmad.net/SRTM15Plus/"); // Previously https://dem.pmad.net/SRTM15Plus/
 
-        public Uri MapToolkitSRTM1 => new Uri("https://dem.pmad.net/SRTM1/");
+        public Uri MapToolkitSRTM1 => new Uri("https://cdn.dem.pmad.net/SRTM1/"); // Previously https://dem.pmad.net/SRTM1/
 
-        public Uri MapToolkitAW3D30 => new Uri("https://dem.pmad.net/AW3D30/");
+        public Uri MapToolkitAW3D30 => new Uri("https://cdn.dem.pmad.net/AW3D30/"); // Previously https://dem.pmad.net/AW3D30/
 
         public Uri WeatherStats => new Uri("https://weatherdata.pmad.net/ERA5AVG/");
 
-        public Uri OverpassApiInterpreter => new Uri("https://overpass-api.de/api/interpreter");
+        public Uri OverpassApiInterpreter => new Uri("https://overpass.pmad.net/api/interpreter"); // Previously https://overpass-api.de/api/interpreter
 
         public Uri SatelliteImageProvider => new Uri("https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2020_3857/default/GoogleMapsCompatible/15/{y}/{x}.jpg");
     }

--- a/GameRealisticMap/Configuration/ISourceLocations.cs
+++ b/GameRealisticMap/Configuration/ISourceLocations.cs
@@ -1,17 +1,39 @@
 ﻿namespace GameRealisticMap.Configuration
 {
+    /// <summary>
+    /// Endpoints to data sources used by the application.
+    /// </summary>
     public interface ISourceLocations
     {
+        /// <summary>
+        /// Endpoint to SRTM15+ elevation data (Pmad.Cartography format, formerly MapToolkit)
+        /// </summary>
         Uri MapToolkitSRTM15Plus { get; }
 
+        /// <summary>
+        /// Endpoint to SRTM1 elevation data (Pmad.Cartography format, formerly MapToolkit)
+        /// </summary>
         Uri MapToolkitSRTM1 { get; }
 
+        /// <summary>
+        /// Endpoint to AW3D30 elevation data (Pmad.Cartography format, formerly MapToolkit)
+        /// </summary>
         Uri MapToolkitAW3D30 { get; }
 
+        /// <summary>
+        /// Endpoint to WeatherStats data, providing weather statistics data (e.g. ERA5AVG) used for climate generation.
+        /// </summary>
         Uri WeatherStats { get; }
 
+        /// <summary>
+        /// Endpoint to Overpass API interpreter, used for querying OpenStreetMap data.
+        /// </summary>
         Uri OverpassApiInterpreter { get; }
 
+        /// <summary>
+        /// Google map compatible WMTS endpoint to satellite image.
+        /// Should have placeholders for {x}, {y}, and optionnaly for {z} (zoom level).
+        /// </summary>
         Uri SatelliteImageProvider { get; }
     }
 }

--- a/GameRealisticMap/Configuration/ISourceLocations.cs
+++ b/GameRealisticMap/Configuration/ISourceLocations.cs
@@ -32,7 +32,7 @@
 
         /// <summary>
         /// Google map compatible WMTS endpoint to satellite image.
-        /// Should have placeholders for {x}, {y}, and optionnaly for {z} (zoom level).
+        /// Should have placeholders for {x}, {y}, and optionally for {z} (zoom level).
         /// </summary>
         Uri SatelliteImageProvider { get; }
     }

--- a/GameRealisticMap/Configuration/SourceLocations.cs
+++ b/GameRealisticMap/Configuration/SourceLocations.cs
@@ -70,7 +70,7 @@ namespace GameRealisticMap.Configuration
         /// <summary>
         /// Loads source locations from <see cref="DefaultLocation"/>.
         /// Applies endpoint migrations when the stored config version is outdated.
-        /// Returns <see cref="DefaultSourceLocations.Instance"/> when no file exists or deserialization fails.
+        /// Returns <see cref="DefaultSourceLocations.Instance"/> when no file exists.
         /// </summary>
         public static Task<ISourceLocations> Load()
         {
@@ -80,7 +80,7 @@ namespace GameRealisticMap.Configuration
         /// <summary>
         /// Loads source locations from <paramref name="path"/>.
         /// Applies endpoint migrations when the stored config version is outdated.
-        /// Returns <see cref="DefaultSourceLocations.Instance"/> when no file exists or deserialization fails.
+        /// Returns <see cref="DefaultSourceLocations.Instance"/> when no file exists.
         /// </summary>
         public static async Task<ISourceLocations> Load(string path)
         {
@@ -106,20 +106,20 @@ namespace GameRealisticMap.Configuration
         }
 
         /// <summary>
-        /// Persists <paramref name="path"/> to <paramref name="location"/>
+        /// Persists <paramref name="locations"/> to <paramref name="path"/>
         /// and stamps the file with <see cref="CurrentConfigVersion"/>.
         /// </summary>
-        public static async Task Save(string location, ISourceLocations path)
+        public static async Task Save(string path, ISourceLocations locations)
         {
-            using var stream = File.Create(location);
+            using var stream = File.Create(path);
             await JsonSerializer.SerializeAsync(stream, new SourceLocationsJson(
-                path.MapToolkitSRTM15Plus,
-                path.MapToolkitSRTM1,
-                path.MapToolkitAW3D30,
-                path.WeatherStats,
-                path.OverpassApiInterpreter,
+                locations.MapToolkitSRTM15Plus,
+                locations.MapToolkitSRTM1,
+                locations.MapToolkitAW3D30,
+                locations.WeatherStats,
+                locations.OverpassApiInterpreter,
                 null,
-                path.SatelliteImageProvider,
+                locations.SatelliteImageProvider,
                 CurrentConfigVersion));
         }
     }

--- a/GameRealisticMap/Configuration/SourceLocations.cs
+++ b/GameRealisticMap/Configuration/SourceLocations.cs
@@ -2,33 +2,125 @@
 
 namespace GameRealisticMap.Configuration
 {
+    /// <summary>
+    /// Handles persistence of <see cref="ISourceLocations"/> to a JSON file,
+    /// including automatic migration of outdated endpoint URLs.
+    /// </summary>
     public static class SourceLocations
     {
+        /// <summary>
+        /// Default path of the JSON file used to persist source locations.
+        /// Located in <c>%LOCALAPPDATA%\GameRealisticMap\sources.json</c>.
+        /// </summary>
         public static string DefaultLocation { get; } = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "GameRealisticMap", "sources.json");
 
-        public static async Task<ISourceLocations> Load()
+        /// <summary>
+        /// Increment this constant whenever a new migration batch is added
+        /// so that already-migrated files are not processed again.
+        /// </summary>
+        private const int CurrentConfigVersion = 1;
+
+        /// <summary>
+        /// Maps obsolete endpoint prefixes to their replacement prefixes.
+        /// </summary>
+        private static readonly (Uri OldPrefix, Uri NewPrefix)[] Migrations = new[]
         {
-            if (File.Exists(DefaultLocation))
+            (new Uri("https://dem.pmad.net/SRTM15Plus/"),        DefaultSourceLocations.Instance.MapToolkitSRTM15Plus),
+            (new Uri("https://dem.pmad.net/SRTM1/"),             DefaultSourceLocations.Instance.MapToolkitSRTM1),
+            (new Uri("https://dem.pmad.net/AW3D30/"),            DefaultSourceLocations.Instance.MapToolkitAW3D30),
+            (new Uri("https://overpass-api.de/api/interpreter"), DefaultSourceLocations.Instance.OverpassApiInterpreter),
+        };
+
+        /// <summary>
+        /// Replaces an obsolete URL prefix with its current equivalent.
+        /// Returns the original <paramref name="uri"/> unchanged if no migration applies.
+        /// </summary>
+        private static Uri Migrate(Uri uri)
+        {
+            var str = uri.OriginalString;
+            foreach (var (oldPrefix, newPrefix) in Migrations)
             {
-                using var stream = File.OpenRead(DefaultLocation);
-                return await JsonSerializer.DeserializeAsync<SourceLocationsJson>(stream) ?? (ISourceLocations)DefaultSourceLocations.Instance;
+                if (str.StartsWith(oldPrefix.OriginalString, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new Uri(newPrefix.OriginalString + str.Substring(oldPrefix.OriginalString.Length));
+                }
+            }
+            return uri;
+        }
+
+        /// <summary>
+        /// Applies all endpoint migrations to <paramref name="json"/> when its
+        /// <see cref="SourceLocationsJson.ConfigVersion"/> is below <see cref="CurrentConfigVersion"/>.
+        /// </summary>
+        private static SourceLocationsJson ApplyMigrations(SourceLocationsJson json)
+        {
+            if (json.ConfigVersion >= CurrentConfigVersion)
+            {
+                return json;
+            }
+            json.MapToolkitSRTM15Plus = Migrate(json.MapToolkitSRTM15Plus);
+            json.MapToolkitSRTM1 = Migrate(json.MapToolkitSRTM1);
+            json.MapToolkitAW3D30 = Migrate(json.MapToolkitAW3D30);
+            json.OverpassApiInterpreter = Migrate(json.OverpassApiInterpreter);
+            return json;
+        }
+
+        /// <summary>
+        /// Loads source locations from <see cref="DefaultLocation"/>.
+        /// Applies endpoint migrations when the stored config version is outdated.
+        /// Returns <see cref="DefaultSourceLocations.Instance"/> when no file exists or deserialization fails.
+        /// </summary>
+        public static Task<ISourceLocations> Load()
+        {
+            return Load(DefaultLocation);
+        }
+
+        /// <summary>
+        /// Loads source locations from <paramref name="path"/>.
+        /// Applies endpoint migrations when the stored config version is outdated.
+        /// Returns <see cref="DefaultSourceLocations.Instance"/> when no file exists or deserialization fails.
+        /// </summary>
+        public static async Task<ISourceLocations> Load(string path)
+        {
+            if (File.Exists(path))
+            {
+                using var stream = File.OpenRead(path);
+                var json = await JsonSerializer.DeserializeAsync<SourceLocationsJson>(stream);
+                if (json != null)
+                {
+                    return ApplyMigrations(json);
+                }
             }
             return DefaultSourceLocations.Instance;
         }
 
-        public static async Task Save(ISourceLocations locations)
+        /// <summary>
+        /// Persists <paramref name="locations"/> to <see cref="DefaultLocation"/>
+        /// and stamps the file with <see cref="CurrentConfigVersion"/>.
+        /// </summary>
+        public static Task Save(ISourceLocations locations)
         {
-            using var stream = File.Create(DefaultLocation);
+            return Save(DefaultLocation, locations);
+        }
+
+        /// <summary>
+        /// Persists <paramref name="path"/> to <paramref name="location"/>
+        /// and stamps the file with <see cref="CurrentConfigVersion"/>.
+        /// </summary>
+        public static async Task Save(string location, ISourceLocations path)
+        {
+            using var stream = File.Create(location);
             await JsonSerializer.SerializeAsync(stream, new SourceLocationsJson(
-                locations.MapToolkitSRTM15Plus,
-                locations.MapToolkitSRTM1,
-                locations.MapToolkitAW3D30,
-                locations.WeatherStats,
-                locations.OverpassApiInterpreter,
+                path.MapToolkitSRTM15Plus,
+                path.MapToolkitSRTM1,
+                path.MapToolkitAW3D30,
+                path.WeatherStats,
+                path.OverpassApiInterpreter,
                 null,
-                locations.SatelliteImageProvider));
+                path.SatelliteImageProvider,
+                CurrentConfigVersion));
         }
     }
 }

--- a/GameRealisticMap/Configuration/SourceLocationsJson.cs
+++ b/GameRealisticMap/Configuration/SourceLocationsJson.cs
@@ -1,7 +1,22 @@
 ﻿namespace GameRealisticMap.Configuration
 {
+    /// <summary>
+    /// JSON-serializable implementation of <see cref="ISourceLocations"/>.
+    /// The <see cref="ConfigVersion"/> field is used to track migration state.
+    /// </summary>
     public sealed class SourceLocationsJson : ISourceLocations
     {
+        /// <summary>
+        /// Initializes a new instance with explicit endpoint URIs.
+        /// </summary>
+        /// <param name="mapToolkitSRTM15Plus">Base URI for SRTM15+ elevation tiles.</param>
+        /// <param name="mapToolkitSRTM1">Base URI for SRTM1 elevation tiles.</param>
+        /// <param name="mapToolkitAW3D30">Base URI for AW3D30 elevation tiles.</param>
+        /// <param name="weatherStats">Base URI for weather statistics data.</param>
+        /// <param name="overpassApiInterpreter">URI of the Overpass API interpreter endpoint.</param>
+        /// <param name="s2CloudlessBasePath">Optional legacy base path for S2 Cloudless tiles; used to derive <see cref="SatelliteImageProvider"/> when <paramref name="satelliteImageProvider"/> is <c>null</c>.</param>
+        /// <param name="satelliteImageProvider">Full URI template for satellite image tiles. Derived from <paramref name="s2CloudlessBasePath"/> or the default when <c>null</c>.</param>
+        /// <param name="configVersion">Config schema version; defaults to <c>0</c> for files that pre-date versioning.</param>
         public SourceLocationsJson(
             Uri mapToolkitSRTM15Plus,
             Uri mapToolkitSRTM1,
@@ -9,8 +24,10 @@
             Uri weatherStats,
             Uri overpassApiInterpreter,
             Uri? s2CloudlessBasePath = null,
-            Uri? satelliteImageProvider = null)
+            Uri? satelliteImageProvider = null,
+            int configVersion = 0)
         {
+            ConfigVersion = configVersion;
             MapToolkitSRTM15Plus = mapToolkitSRTM15Plus;
             MapToolkitSRTM1 = mapToolkitSRTM1;
             MapToolkitAW3D30 = mapToolkitAW3D30;
@@ -34,6 +51,12 @@
                 SatelliteImageProvider = satelliteImageProvider;
             }
         }
+
+        /// <summary>
+        /// Config schema version stored in the JSON file.
+        /// A value of <c>0</c> means the file predates versioning and may need migration.
+        /// </summary>
+        public int ConfigVersion { get; init; }
 
         public Uri MapToolkitSRTM15Plus { get; set; }
         public Uri MapToolkitSRTM1 { get; set; }

--- a/GameRealisticMap/GameRealisticMap.csproj
+++ b/GameRealisticMap/GameRealisticMap.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Pmad.Cartography" Version="0.1.20" />
+		<PackageReference Include="Pmad.Cartography" Version="0.1.23" />
 		<ProjectReference Include="..\weatherstats\WeatherStats\WeatherStats.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
Some endpoints have changed, this PR applies new recommandations:
- Elevation data is migrating to a CDN to reduce storage requirement on main server.
- An overpass mirror have been created to reduce stress on official server.

Pmad.Cartography have been updated to a new version that offers better CDN support (retry, integrity check, and user-agent).